### PR TITLE
TW-322: after denied photo access, can't click to camera

### DIFF
--- a/lib/images_picker/image_picker.dart
+++ b/lib/images_picker/image_picker.dart
@@ -17,6 +17,7 @@ class ImagePicker {
     Widget? cameraWidget,
     Widget? bottomWidget,
     ImageProvider<Object>? backgroundImageCamera,
+    void Function()? onCameraPressed,
     Color? backgroundColor,
     Color? assetBackgroundColor,
     Widget? selectMoreImageWidget,
@@ -41,7 +42,10 @@ class ImagePicker {
       if (permissionStatus == PermissionStatus.permanentlyDenied || permissionStatus == PermissionStatus.denied) {
         return PermissionNotAuthorizedWidget(
           backgroundColor: backgroundColor,
+          backgroundImageCamera: backgroundImageCamera,
           goToSettingsWidget: goToSettingsWidget,
+          cameraWidget: cameraWidget,
+          onCameraPressed: onCameraPressed,
         );
       } else {
         if (assetPathEntity != null) {
@@ -52,10 +56,12 @@ class ImagePicker {
                 controller: controller,
                 assetBackgroundColor: assetBackgroundColor,
                 backgroundImageCamera: backgroundImageCamera,
+                onCameraPressed: onCameraPressed,
                 cameraWidget: cameraWidget,
                 selectMoreImageWidget: selectMoreImageWidget,
                 isLimitSelectImage: permissionStatus == PermissionStatus.limited,
-                scrollController: scrollController)
+                scrollController: scrollController,
+              )
             : ImagesPickerGrid(
                 assetPath: assetPathEntity,
                 controller: controller,
@@ -64,7 +70,9 @@ class ImagePicker {
                 backgroundImage: backgroundImageCamera,
                 selectMoreImageWidget: selectMoreImageWidget,
                 isLimitSelectImage: permissionStatus == PermissionStatus.limited,
-                cameraWidget: cameraWidget);
+                cameraWidget: cameraWidget,
+                onCameraPressed: onCameraPressed,
+              );
         } else {
           return const SizedBox.shrink();
         }

--- a/lib/images_picker/image_picker_grid_with_counter.dart
+++ b/lib/images_picker/image_picker_grid_with_counter.dart
@@ -24,6 +24,8 @@ class ImagePickerGridWithCounter extends StatefulWidget {
 
   final ScrollController scrollController;
 
+  final void Function()? onCameraPressed;
+
   const ImagePickerGridWithCounter({
     super.key,
     required this.assetPath,
@@ -34,7 +36,8 @@ class ImagePickerGridWithCounter extends StatefulWidget {
     this.backgroundImageCamera,
     this.controller,
     this.isLimitSelectImage = false,
-    this.selectMoreImageWidget
+    this.selectMoreImageWidget,
+    this.onCameraPressed,
   });
 
   @override
@@ -96,6 +99,7 @@ class _ImagePickerGridWithCounterState extends State<ImagePickerGridWithCounter>
               isLimitSelectImage: widget.isLimitSelectImage,
               selectMoreImageWidget: widget.selectMoreImageWidget,
               scrollController: widget.scrollController,
+              onCameraPressed: widget.onCameraPressed,
             ),
           ),
         ),

--- a/lib/images_picker/view_permission_not_authorized.dart
+++ b/lib/images_picker/view_permission_not_authorized.dart
@@ -10,7 +10,8 @@ class PermissionNotAuthorizedWidget extends StatelessWidget {
     this.backgroundColor,
     this.goToSettingsWidget,
     this.onCameraPressed,
-    this.backgroundImageCamera
+    this.backgroundImageCamera,
+    this.cameraWidget,
   });
 
   final Color? backgroundColor;
@@ -20,6 +21,8 @@ class PermissionNotAuthorizedWidget extends StatelessWidget {
   final ImageProvider<Object>? backgroundImageCamera;
 
   final void Function()? onCameraPressed;
+
+  final Widget? cameraWidget;
 
   @override
   Widget build(BuildContext context) {
@@ -41,10 +44,10 @@ class PermissionNotAuthorizedWidget extends StatelessWidget {
             ),
             childrenDelegate: SliverChildBuilderDelegate((context, index) {
               if (index == 0) {
-                return UseCameraWidget(
-                  onPressed: onCameraPressed,
-                  backgroundImage: backgroundImageCamera
-                );
+                return cameraWidget ?? UseCameraWidget(
+                     backgroundImage: backgroundImageCamera,
+                     onPressed: onCameraPressed,
+                  );
               }
               return GestureDetector(
                 onTap: () => PhotoManager.openSetting(),


### PR DESCRIPTION


https://github.com/linagora/linagora-design-flutter/assets/43041967/f8d9fb58-e389-4ab0-8aca-d67483a0c604


https://github.com/linagora/linagora-design-flutter/assets/43041967/feb765d5-9270-4a50-8357-6f780821bb06

## Cause: 
After denied photo access, it use the default `UseCamera` widget, but not the one user pass in