### PR TITLE
Add first version of MessageBubble

### DIFF
--- a/lib/chat/bubble_shape.dart
+++ b/lib/chat/bubble_shape.dart
@@ -75,6 +75,16 @@ class BubbleShape extends ShapeBorder {
     ).shift(rect.topLeft);
   }
 
+  /// Builds the tail as the raw Bézier path exported from Figma, anchored to a
+  /// bottom corner of the bubble.
+  ///
+  /// The `cubicTo`/`lineTo` literals below are the tail's coordinates in
+  /// Figma's own coordinate space (a ~14×19 viewBox). The [x]/[y] helpers map
+  /// that space onto the bubble: the tail's attachment point — design
+  /// coordinate (9, 19), i.e. the bottom corner where the tail meets the
+  /// bubble — is translated onto ([anchorX], [anchorY]). Hence the `- 9` /
+  /// `- 19` offsets. [mirrored] flips the tail horizontally (left vs right
+  /// direction) via the sign [s].
   static Path _tailPath({
     required double anchorX,
     required double anchorY,

--- a/lib/chat/bubble_shape.dart
+++ b/lib/chat/bubble_shape.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
-import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 
 enum BubbleTailDirection { none, left, right }
 
@@ -10,31 +9,6 @@ abstract class BubbleRadius {
 
   static const BorderRadius all = BorderRadius.all(regular);
 }
-
-/// Figma "Body" drop shadow: y1.22, blur0.61, black at 10%.
-const List<BoxShadow> kBubbleShadow = [
-  BoxShadow(
-    color: Color(0x1A000000),
-    offset: Offset(0, 1.22),
-    blurRadius: 0.61,
-  ),
-];
-
-/// Figma bubble body inner padding: 12 horizontal, 8 top, 0 bottom.
-const EdgeInsets kBubbleContentPadding = EdgeInsets.only(
-  left: LinagoraSpacing.base * 1.5,
-  right: LinagoraSpacing.base * 1.5,
-  top: LinagoraSpacing.base,
-);
-
-/// Inner padding for a bubble whose sole content is a media element
-/// (image/video): 4px on every side.
-const EdgeInsets kBubbleMediaContentPadding = EdgeInsets.all(
-  LinagoraSpacing.base * 0.5,
-);
-
-/// Vertical space reserved below a bubble for the reactions overlay.
-const double kMessageReactionsOverlayHeight = LinagoraSpacing.base * 3;
 
 /// A [ShapeBorder] for a rounded chat bubble with an optional bottom tail.
 class BubbleShape extends ShapeBorder {

--- a/lib/chat/bubble_shape.dart
+++ b/lib/chat/bubble_shape.dart
@@ -23,7 +23,7 @@ class BubbleShape extends ShapeBorder {
   });
 
   @override
-  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+  EdgeInsetsGeometry get dimensions => EdgeInsets.all(side.width);
 
   @override
   ShapeBorder scale(double t) => BubbleShape(

--- a/lib/chat/bubble_shape.dart
+++ b/lib/chat/bubble_shape.dart
@@ -27,6 +27,12 @@ const EdgeInsets kBubbleContentPadding = EdgeInsets.only(
   top: LinagoraSpacing.base,
 );
 
+/// Inner padding for a bubble whose sole content is a media element
+/// (image/video): 4px on every side.
+const EdgeInsets kBubbleMediaContentPadding = EdgeInsets.all(
+  LinagoraSpacing.base * 0.5,
+);
+
 /// Vertical space reserved below a bubble for the reactions overlay.
 const double kMessageReactionsOverlayHeight = LinagoraSpacing.base * 3;
 

--- a/lib/chat/bubble_shape.dart
+++ b/lib/chat/bubble_shape.dart
@@ -1,0 +1,159 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
+
+enum BubbleTailDirection { none, left, right }
+
+abstract class BubbleRadius {
+  static const Radius regular = Radius.circular(16);
+
+  static const BorderRadius all = BorderRadius.all(regular);
+}
+
+/// Figma "Body" drop shadow: y1.22, blur0.61, black at 10%.
+const List<BoxShadow> kBubbleShadow = [
+  BoxShadow(
+    color: Color(0x1A000000),
+    offset: Offset(0, 1.22),
+    blurRadius: 0.61,
+  ),
+];
+
+/// Figma bubble body inner padding: 12 horizontal, 8 top, 0 bottom.
+const EdgeInsets kBubbleContentPadding = EdgeInsets.only(
+  left: LinagoraSpacing.base * 1.5,
+  right: LinagoraSpacing.base * 1.5,
+  top: LinagoraSpacing.base,
+);
+
+/// Vertical space reserved below a bubble for the reactions overlay.
+const double kMessageReactionsOverlayHeight = LinagoraSpacing.base * 3;
+
+/// A [ShapeBorder] for a rounded chat bubble with an optional bottom tail.
+class BubbleShape extends ShapeBorder {
+  final BorderRadius borderRadius;
+  final BorderSide side;
+  final BubbleTailDirection tailDirection;
+
+  const BubbleShape({
+    this.borderRadius = BubbleRadius.all,
+    this.side = BorderSide.none,
+    this.tailDirection = BubbleTailDirection.none,
+  });
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  ShapeBorder scale(double t) => BubbleShape(
+        borderRadius: borderRadius * t,
+        side: side.scale(t),
+        tailDirection: tailDirection,
+      );
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect.deflate(side.width));
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    if (side.style == BorderStyle.solid && side.width > 0) {
+      canvas.drawPath(
+        getOuterPath(rect, textDirection: textDirection),
+        side.toPaint()
+          ..strokeJoin = StrokeJoin.round
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+  }
+
+  Path _buildPath(Rect rect) {
+    final hasLeft = tailDirection == BubbleTailDirection.left;
+    final hasRight = tailDirection == BubbleTailDirection.right;
+    final bubbleRect = Offset.zero & rect.size;
+    final bubblePath = Path()..addRRect(borderRadius.toRRect(bubbleRect));
+
+    if (tailDirection == BubbleTailDirection.none) {
+      return bubblePath.shift(rect.topLeft);
+    }
+
+    final tailPath = _tailPath(
+      anchorX: hasRight ? bubbleRect.right : bubbleRect.left,
+      anchorY: bubbleRect.bottom,
+      mirrored: hasLeft,
+    );
+
+    return Path.combine(
+      PathOperation.union,
+      bubblePath,
+      tailPath,
+    ).shift(rect.topLeft);
+  }
+
+  static Path _tailPath({
+    required double anchorX,
+    required double anchorY,
+    required bool mirrored,
+  }) {
+    final s = mirrored ? -1.0 : 1.0;
+    double x(double designX) => anchorX + (designX - 9) * s;
+    double y(double designY) => anchorY + (designY - 19);
+
+    final path = ui.Path()..moveTo(x(9), y(11.5166));
+    path.cubicTo(
+      x(9.75872),
+      y(13.7447), //
+      x(11.0429),
+      y(15.8486), //
+      x(13.1611),
+      y(18.1309),
+    );
+    path.cubicTo(
+      x(13.464),
+      y(18.4574), //
+      x(13.2403),
+      y(18.9997), //
+      x(12.7949),
+      y(18.9922),
+    );
+    path.cubicTo(
+      x(9.40352),
+      y(18.9347), //
+      x(3.38509),
+      y(18.4463), //
+      x(0.22168),
+      y(14.3027),
+    );
+    path.cubicTo(
+      x(0.153575),
+      y(14.2134), //
+      x(0.121483),
+      y(14.1064), //
+      x(0.125),
+      y(14),
+    );
+    path.lineTo(x(0), y(14));
+    path.lineTo(x(0), y(0));
+    path.lineTo(x(9), y(0));
+    path.close();
+    return path;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is BubbleShape &&
+        other.borderRadius == borderRadius &&
+        other.side == side &&
+        other.tailDirection == tailDirection;
+  }
+
+  @override
+  int get hashCode => Object.hash(borderRadius, side, tailDirection);
+}

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -3,12 +3,21 @@ import 'package:linagora_design_flutter/chat/bubble_shape.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 
+/// The kind of content a [MessageBubble] holds, used to pick its inner padding.
+enum BubbleContentType {
+  /// The bubble's sole content is a media element (image/video).
+  mediaOnly,
+
+  /// Default: any other content (text, file, caption, reply…).
+  other,
+}
+
 /// A rounded, filled chat message bubble with an optional tail, holding [child].
 ///
-/// When [color] / [padding] are null they fall back to the design-system
-/// defaults (own vs received color from [isOwnMessage], [kBubbleContentPadding]).
-/// [hasReactions] reserves [kMessageReactionsOverlayHeight] below the bubble for
-/// the reactions overlay.
+/// When [color] is null it falls back to the design-system default (own vs
+/// received color from [isOwnMessage]). When [padding] is null the inner
+/// padding is resolved from [contentType]. [hasReactions] reserves
+/// [kMessageReactionsOverlayHeight] below the bubble for the reactions overlay.
 class MessageBubble extends StatelessWidget {
   final Widget child;
 
@@ -20,7 +29,11 @@ class MessageBubble extends StatelessWidget {
 
   final BorderRadius borderRadius;
 
+  /// Explicit inner padding override. When null, the padding is derived from
+  /// [contentType].
   final EdgeInsetsGeometry? padding;
+
+  final BubbleContentType contentType;
 
   final List<BoxShadow> shadows;
 
@@ -36,10 +49,18 @@ class MessageBubble extends StatelessWidget {
     this.tailDirection = BubbleTailDirection.none,
     this.borderRadius = BubbleRadius.all,
     this.padding,
+    this.contentType = BubbleContentType.other,
     this.shadows = kBubbleShadow,
     this.constraints,
     this.hasReactions = false,
   });
+
+  EdgeInsetsGeometry get _resolvedPadding =>
+      padding ??
+      switch (contentType) {
+        BubbleContentType.mediaOnly => kBubbleMediaContentPadding,
+        BubbleContentType.other => kBubbleContentPadding,
+      };
 
   Color get _resolvedColor =>
       color ??
@@ -54,7 +75,7 @@ class MessageBubble extends StatelessWidget {
       margin: hasReactions
           ? const EdgeInsets.only(bottom: kMessageReactionsOverlayHeight)
           : null,
-      padding: padding ?? kBubbleContentPadding,
+      padding: _resolvedPadding,
       decoration: ShapeDecoration(
         color: _resolvedColor,
         shadows: shadows,

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/chat/bubble_shape.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 
 /// The kind of content a [MessageBubble] holds, used to pick its inner padding.
 enum BubbleContentType {
@@ -11,6 +12,31 @@ enum BubbleContentType {
   /// Default: any other content (text, file, caption, reply…).
   other,
 }
+
+/// Figma bubble body inner padding: 12 horizontal, 8 top, 0 bottom.
+const EdgeInsets kBubbleContentPadding = EdgeInsets.only(
+  left: LinagoraSpacing.base * 1.5,
+  right: LinagoraSpacing.base * 1.5,
+  top: LinagoraSpacing.base,
+);
+
+/// Inner padding for a bubble whose sole content is a media element
+/// (image/video): 4px on every side.
+const EdgeInsets kBubbleMediaContentPadding = EdgeInsets.all(
+  LinagoraSpacing.base * 0.5,
+);
+
+/// Figma "Body" drop shadow: y1.22, blur0.61, black at 10%.
+const List<BoxShadow> kBubbleShadow = [
+  BoxShadow(
+    color: Color(0x1A000000),
+    offset: Offset(0, 1.22),
+    blurRadius: 0.61,
+  ),
+];
+
+/// Vertical space reserved below a bubble for the reactions overlay.
+const double kMessageReactionsOverlayHeight = LinagoraSpacing.base * 3;
 
 /// A rounded, filled chat message bubble with an optional tail, holding [child].
 ///

--- a/lib/chat/message_bubble.dart
+++ b/lib/chat/message_bubble.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/chat/bubble_shape.dart';
+import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
+import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+
+/// A rounded, filled chat message bubble with an optional tail, holding [child].
+///
+/// When [color] / [padding] are null they fall back to the design-system
+/// defaults (own vs received color from [isOwnMessage], [kBubbleContentPadding]).
+/// [hasReactions] reserves [kMessageReactionsOverlayHeight] below the bubble for
+/// the reactions overlay.
+class MessageBubble extends StatelessWidget {
+  final Widget child;
+
+  final bool isOwnMessage;
+
+  final Color? color;
+
+  final BubbleTailDirection tailDirection;
+
+  final BorderRadius borderRadius;
+
+  final EdgeInsetsGeometry? padding;
+
+  final List<BoxShadow> shadows;
+
+  final BoxConstraints? constraints;
+
+  final bool hasReactions;
+
+  const MessageBubble({
+    super.key,
+    required this.child,
+    this.isOwnMessage = false,
+    this.color,
+    this.tailDirection = BubbleTailDirection.none,
+    this.borderRadius = BubbleRadius.all,
+    this.padding,
+    this.shadows = kBubbleShadow,
+    this.constraints,
+    this.hasReactions = false,
+  });
+
+  Color get _resolvedColor =>
+      color ??
+      (isOwnMessage
+          ? LinagoraRefColors.material().primary[95]!
+          : LinagoraSysColors.material().onPrimary);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: constraints,
+      margin: hasReactions
+          ? const EdgeInsets.only(bottom: kMessageReactionsOverlayHeight)
+          : null,
+      padding: padding ?? kBubbleContentPadding,
+      decoration: ShapeDecoration(
+        color: _resolvedColor,
+        shadows: shadows,
+        shape: BubbleShape(
+          borderRadius: borderRadius,
+          tailDirection: tailDirection,
+        ),
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/linagora_design_flutter.dart
+++ b/lib/linagora_design_flutter.dart
@@ -20,3 +20,5 @@ export 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 export 'package:linagora_design_flutter/buttons/linagora_button.dart';
 export 'package:linagora_design_flutter/buttons/linagora_button_size.dart';
 export 'package:linagora_design_flutter/buttons/linagora_button_variant.dart';
+export 'package:linagora_design_flutter/chat/bubble_shape.dart';
+export 'package:linagora_design_flutter/chat/message_bubble.dart';

--- a/lib/style/linagora_text_style.dart
+++ b/lib/style/linagora_text_style.dart
@@ -24,31 +24,37 @@ class LinagoraTextStyle {
   LinagoraTextStyle._material()
       : bodyLarge1 = const TextStyle(
           fontSize: 17,
+          height: 24 / 17,
           fontWeight: FontWeight.w600,
           letterSpacing: -0.15,
         ),
         bodyLarge2 = const TextStyle(
           fontSize: 17,
+          height: 24 / 17,
           fontWeight: FontWeight.w400,
           letterSpacing: -0.15,
         ),
         bodyMedium = const TextStyle(
           fontSize: 14,
+          height: 20 / 14,
           fontWeight: FontWeight.w500,
           letterSpacing: 0.25,
         ),
         bodyMedium1 = const TextStyle(
           fontSize: 16,
+          height: 24 / 16,
           fontWeight: FontWeight.w400,
           letterSpacing: -0.15,
         ),
         bodyMedium2 = const TextStyle(
           fontSize: 14,
+          height: 20 / 14,
           fontWeight: FontWeight.w600,
           letterSpacing: 0.25,
         ),
         bodyMedium3 = const TextStyle(
           fontSize: 14,
+          height: 20 / 14,
           fontWeight: FontWeight.w400,
           letterSpacing: 0.25,
         );

--- a/lib/style/linagora_text_style.dart
+++ b/lib/style/linagora_text_style.dart
@@ -3,52 +3,80 @@ import 'package:flutter/painting.dart';
 
 class LinagoraTextStyle {
   // Display
+
+  /// 57px · Bold (w700).
   final TextStyle displayLarge;
 
+  /// 45px · SemiBold (w600).
   final TextStyle displayMedium;
 
+  /// 36px · SemiBold (w600).
   final TextStyle displaySmall;
 
   // Headline
+
+  /// 32px · SemiBold (w600).
   final TextStyle headlineLarge;
 
+  /// 28px · SemiBold (w600).
   final TextStyle headlineMedium;
 
+  /// 24px · SemiBold (w600).
   final TextStyle headlineSmall;
 
   // Title
+
+  /// 22px · SemiBold (w600).
   final TextStyle titleLarge;
 
+  /// 16px · Medium (w500).
   final TextStyle titleMedium;
 
+  /// 16px · SemiBold (w600). Same size as [titleMedium], heavier weight.
   final TextStyle titleSemibold;
 
+  /// 14px · Medium (w500).
   final TextStyle titleSmall;
 
   // Label
+
+  /// 14px · Medium (w500).
   final TextStyle labelLarge;
 
+  /// 12px · Medium (w500).
   final TextStyle labelMedium;
 
+  /// 11px · Medium (w500).
   final TextStyle labelSmall;
 
-  // Body
+  // Body — the numeric suffixes are a Figma import legacy and only vary the
+  // weight at a shared font size as of now
+
+  /// 17px · Medium (w500). Default body large (Figma token `M3/body/large`).
   final TextStyle bodyLarge;
 
+  /// 17px · Bold (w700).
   final TextStyle bodyLargeBold;
 
+  /// 17px · SemiBold (w600).
   final TextStyle bodyLarge1;
 
+  /// 17px · Regular (w400).
   final TextStyle bodyLarge2;
 
+  /// 16px · Regular (w400).
   final TextStyle bodyMedium1;
 
+  /// 14px · SemiBold (w600).
   final TextStyle bodyMedium2;
 
+  /// 14px · Medium (w500). Default body medium (Figma token `M3/body/medium`).
   final TextStyle bodyMedium;
 
+  /// 14px · Regular (w400).
   final TextStyle bodyMedium3;
 
+  /// 12px · Medium (w500).
   final TextStyle bodySmall;
 
   static final LinagoraTextStyle _materialLinagoraTextStyle =

--- a/lib/style/linagora_text_style.dart
+++ b/lib/style/linagora_text_style.dart
@@ -2,17 +2,54 @@
 import 'package:flutter/painting.dart';
 
 class LinagoraTextStyle {
+  // Display
+  final TextStyle displayLarge;
+
+  final TextStyle displayMedium;
+
+  final TextStyle displaySmall;
+
+  // Headline
+  final TextStyle headlineLarge;
+
+  final TextStyle headlineMedium;
+
+  final TextStyle headlineSmall;
+
+  // Title
+  final TextStyle titleLarge;
+
+  final TextStyle titleMedium;
+
+  final TextStyle titleSemibold;
+
+  final TextStyle titleSmall;
+
+  // Label
+  final TextStyle labelLarge;
+
+  final TextStyle labelMedium;
+
+  final TextStyle labelSmall;
+
+  // Body
+  final TextStyle bodyLarge;
+
+  final TextStyle bodyLargeBold;
+
   final TextStyle bodyLarge1;
 
   final TextStyle bodyLarge2;
-
-  final TextStyle bodyMedium;
 
   final TextStyle bodyMedium1;
 
   final TextStyle bodyMedium2;
 
+  final TextStyle bodyMedium;
+
   final TextStyle bodyMedium3;
+
+  final TextStyle bodySmall;
 
   static final LinagoraTextStyle _materialLinagoraTextStyle =
       LinagoraTextStyle._material();
@@ -22,7 +59,97 @@ class LinagoraTextStyle {
   }
 
   LinagoraTextStyle._material()
-      : bodyLarge1 = const TextStyle(
+      : displayLarge = const TextStyle(
+          fontSize: 57,
+          height: 64 / 57,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0,
+        ),
+        displayMedium = const TextStyle(
+          fontSize: 45,
+          height: 52 / 45,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        displaySmall = const TextStyle(
+          fontSize: 36,
+          height: 44 / 36,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        headlineLarge = const TextStyle(
+          fontSize: 32,
+          height: 40 / 32,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        headlineMedium = const TextStyle(
+          fontSize: 28,
+          height: 36 / 28,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        headlineSmall = const TextStyle(
+          fontSize: 24,
+          height: 32 / 24,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        titleLarge = const TextStyle(
+          fontSize: 22,
+          height: 28 / 22,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0,
+        ),
+        titleMedium = const TextStyle(
+          fontSize: 16,
+          height: 24 / 16,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.15,
+        ),
+        titleSemibold = const TextStyle(
+          fontSize: 16,
+          height: 24 / 16,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.15,
+        ),
+        titleSmall = const TextStyle(
+          fontSize: 14,
+          height: 20 / 14,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelLarge = const TextStyle(
+          fontSize: 14,
+          height: 20 / 14,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.1,
+        ),
+        labelMedium = const TextStyle(
+          fontSize: 12,
+          height: 16 / 12,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        labelSmall = const TextStyle(
+          fontSize: 11,
+          height: 16 / 11,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.5,
+        ),
+        bodyLarge = const TextStyle(
+          fontSize: 17,
+          height: 24 / 17,
+          fontWeight: FontWeight.w500,
+          letterSpacing: -0.15,
+        ),
+        bodyLargeBold = const TextStyle(
+          fontSize: 17,
+          height: 24 / 17,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.15,
+        ),
+        bodyLarge1 = const TextStyle(
           fontSize: 17,
           height: 24 / 17,
           fontWeight: FontWeight.w600,
@@ -33,12 +160,6 @@ class LinagoraTextStyle {
           height: 24 / 17,
           fontWeight: FontWeight.w400,
           letterSpacing: -0.15,
-        ),
-        bodyMedium = const TextStyle(
-          fontSize: 14,
-          height: 20 / 14,
-          fontWeight: FontWeight.w500,
-          letterSpacing: 0.25,
         ),
         bodyMedium1 = const TextStyle(
           fontSize: 16,
@@ -52,10 +173,22 @@ class LinagoraTextStyle {
           fontWeight: FontWeight.w600,
           letterSpacing: 0.25,
         ),
+        bodyMedium = const TextStyle(
+          fontSize: 14,
+          height: 20 / 14,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.25,
+        ),
         bodyMedium3 = const TextStyle(
           fontSize: 14,
           height: 20 / 14,
           fontWeight: FontWeight.w400,
           letterSpacing: 0.25,
+        ),
+        bodySmall = const TextStyle(
+          fontSize: 12,
+          height: 16 / 12,
+          fontWeight: FontWeight.w500,
+          letterSpacing: 0.4,
         );
 }

--- a/widgetbook/lib/components/chat/message_bubble_use_case.dart
+++ b/widgetbook/lib/components/chat/message_bubble_use_case.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'Default', type: MessageBubble)
+Widget messageBubbleUseCase(BuildContext context) {
+  final isOwnMessage = context.knobs.boolean(
+    label: 'Own message',
+    initialValue: false,
+  );
+  final showTail = context.knobs.boolean(
+    label: 'Show tail',
+    initialValue: true,
+  );
+  final text = context.knobs.string(
+    label: 'Message',
+    initialValue: 'Hello! I am a beautiful chat bubble 👋',
+  );
+
+  final tailDirection = showTail
+      ? (isOwnMessage ? BubbleTailDirection.right : BubbleTailDirection.left)
+      : BubbleTailDirection.none;
+
+  final bubble = MessageBubble(
+    isOwnMessage: isOwnMessage,
+    tailDirection: tailDirection,
+    constraints: const BoxConstraints(maxWidth: 280),
+    // Bubble body has no bottom padding; the content owns the space below it.
+    child: Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(text, style: LinagoraTextStyle.material().bodyMedium3),
+    ),
+  );
+
+  return ColoredBox(
+    color: const Color(0xFFF5F7FA),
+    child: Padding(
+      padding: const EdgeInsets.all(LinagoraSpacing.base * 3),
+      child: Align(
+        alignment:
+            isOwnMessage ? Alignment.centerRight : Alignment.centerLeft,
+        child: bubble,
+      ),
+    ),
+  );
+}

--- a/widgetbook/lib/widgetbook.dart
+++ b/widgetbook/lib/widgetbook.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:widgetbook/widgetbook.dart' hide AlignmentAddon;
 import 'package:widgetbook_workspace/components/buttons/linagora_button_use_case.dart';
+import 'package:widgetbook_workspace/components/chat/message_bubble_use_case.dart';
 import 'package:widgetbook_workspace/components/contact_component/matrix_contact_use_case.dart';
 import 'package:widgetbook_workspace/components/contact_component/phonebook_contact_use_case.dart';
 import 'package:widgetbook_workspace/custom/github_addon.dart';
@@ -79,6 +80,20 @@ class WidgetbookApp extends StatelessWidget {
                 WidgetbookUseCase(
                   name: 'Default',
                   builder: (context) => linagoraButtonUseCase(context),
+                ),
+              ],
+            ),
+          ],
+        ),
+        WidgetbookFolder(
+          name: 'Chat',
+          children: [
+            WidgetbookComponent(
+              name: 'Message bubble',
+              useCases: [
+                WidgetbookUseCase(
+                  name: 'Default',
+                  builder: (context) => messageBubbleUseCase(context),
                 ),
               ],
             ),


### PR DESCRIPTION
## Changes
- Add height to LinagoraTextStyle and add more tokens as per figma DS
- Add first version of MessageBubble including some UI changes requested by https://github.com/linagora/twake-on-matrix/issues/3052 (radius, color, tail, inner-padding)

<img width="2302" height="1177" alt="Capture d’écran 2026-06-05 à 08 56 19" src="https://github.com/user-attachments/assets/a6bf9c97-fd73-475e-83c9-781e1d12ae99" />
