### PR TITLE
Right click focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1 - 2026-06-16
+
+### Added
+
+* `RightClickFocus`: Gives [focusNode] focus when its subtree receives a secondary (right) mouse button press, web only.
+
 ## 0.1.0 - 2026-06-08
 
 ### Added

--- a/lib/behaviors/right_click_focus.dart
+++ b/lib/behaviors/right_click_focus.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/widgets.dart';
+
+/// Gives [focusNode] focus when its subtree receives a secondary (right) mouse
+/// button press, on web only.
+class RightClickFocus extends StatelessWidget {
+  const RightClickFocus({super.key, required this.child, this.focusNode});
+
+  final Widget child;
+
+  final FocusNode? focusNode;
+
+  @override
+  Widget build(BuildContext context) {
+    final node = focusNode;
+    const isWeb = kIsWeb;
+    if (node == null || !isWeb) return child;
+    return Listener(
+      onPointerDown: (event) {
+        if (!node.hasFocus &&
+            event.kind == PointerDeviceKind.mouse &&
+            (event.buttons & kSecondaryMouseButton) != 0) {
+          node.requestFocus();
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/linagora_design_flutter.dart
+++ b/lib/linagora_design_flutter.dart
@@ -22,3 +22,4 @@ export 'package:linagora_design_flutter/buttons/linagora_button_size.dart';
 export 'package:linagora_design_flutter/buttons/linagora_button_variant.dart';
 export 'package:linagora_design_flutter/chat/bubble_shape.dart';
 export 'package:linagora_design_flutter/chat/message_bubble.dart';
+export 'package:linagora_design_flutter/behaviors/right_click_focus.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linagora_design_flutter
 description: Common widgets for Linagora products
-version: 0.1.0
+version: 0.1.1
 # Remove this later when publishing to pub.dev.
 publish_to: none
 


### PR DESCRIPTION
Same behavior as https://github.com/linagora/twake-on-matrix/pull/3143

### Added

* `RightClickFocus`: Gives [focusNode] focus when its subtree receives a secondary (right) mouse button press, web only.