### PR TITLE
[TF-4678][Part 1] Sidebar item states and virtualized tree list

### DIFF
--- a/lib/linagora_design_flutter.dart
+++ b/lib/linagora_design_flutter.dart
@@ -32,5 +32,8 @@ export 'package:linagora_design_flutter/banners/linagora_banner.dart';
 export 'package:linagora_design_flutter/text_field/linagora_text_field.dart';
 export 'package:linagora_design_flutter/text_field/linagora_text_field_variant.dart';
 export 'package:linagora_design_flutter/sidebar/linagora_sidebar_badge.dart';
+export 'package:linagora_design_flutter/sidebar/linagora_sidebar_indent.dart';
 export 'package:linagora_design_flutter/sidebar/linagora_sidebar_item.dart';
 export 'package:linagora_design_flutter/sidebar/linagora_sidebar_style.dart';
+export 'package:linagora_design_flutter/sidebar/linagora_sidebar_sub_item.dart';
+export 'package:linagora_design_flutter/sidebar/linagora_sidebar_tree_list.dart';

--- a/lib/sidebar/linagora_sidebar_badge.dart
+++ b/lib/sidebar/linagora_sidebar_badge.dart
@@ -1,6 +1,7 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_style.dart';
-import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
 /// The counter pill at the end of a [LinagoraSidebarItem].
 ///
@@ -29,20 +30,19 @@ class LinagoraSidebarBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final style = this.style ?? LinagoraSidebarStyle.of(context);
-    final textStyle = LinagoraTextTheme.material().labelSmall?.copyWith(
+    final textStyle = style.badgeTextStyle.copyWith(
       color: foregroundColor ?? style.badgeForeground,
     );
+    final counter = _measureCounter(context, textStyle, style.badgeHeight);
 
     return ConstrainedBox(
       constraints: BoxConstraints(
-        maxWidth: _widestWidth(context, textStyle) +
-            style.badgeHorizontalPadding * 2,
+        maxWidth: counter.width + style.badgeHorizontalPadding * 2,
       ),
       child: Container(
-        // No alignment: a centred Container fills the constraints it is given
-        // rather than hugging its label — vertically that stretched the pill
-        // to the row height, horizontally to the cap. The minimum keeps a
-        // single digit round; [Text.textAlign] centres it inside that.
+        // No alignment on the Container: it would fill the constraints it
+        // is given rather than hug its counter. The minimum keeps a single
+        // digit round.
         constraints: BoxConstraints(
           minWidth: style.badgeHeight,
           minHeight: style.badgeHeight,
@@ -54,31 +54,80 @@ class LinagoraSidebarBadge extends StatelessWidget {
           color: backgroundColor ?? style.badgeBackground,
           shape: const StadiumBorder(),
         ),
-        child: Text(
-          label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.center,
-          style: textStyle,
+        // The factors hug the counter and centre it across a pill the
+        // minimum has widened. Down the pill the inset places it, so this
+        // alignment stays at the top.
+        child: Align(
+          alignment: Alignment.topCenter,
+          widthFactor: 1,
+          heightFactor: 1,
+          child: Padding(
+            padding: EdgeInsets.only(top: counter.topInset),
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              textHeightBehavior: LinagoraSidebarStyle.middleAligned,
+              style: textStyle,
+            ),
+          ),
         ),
       ),
     );
   }
 
-  double _widestWidth(BuildContext context, TextStyle? textStyle) {
+  /// The pill's width ceiling, and how far its counter is dropped inside it.
+  ///
+  /// The inset centres the digits' *ink*. Centring the paragraph box instead
+  /// lands them low, by the font's descent plus whatever the engine rounds off
+  /// the ascent — most of a pixel on a pill only 16 tall.
+  ({double width, double topInset}) _measureCounter(
+    BuildContext context,
+    TextStyle textStyle,
+    double pillHeight,
+  ) {
+    final textScaler = MediaQuery.textScalerOf(context);
     final painter = TextPainter(
-      text: TextSpan(text: widestLabel, style: textStyle),
+      // Measured on the glyphs, as the counter is drawn: the line height
+      // would otherwise report a baseline pushed down by its leading.
+      text: TextSpan(
+        text: widestLabel,
+        style: textStyle.copyWith(height: kTextHeightNone),
+      ),
       textDirection: Directionality.of(context),
-      textScaler: MediaQuery.textScalerOf(context),
+      textScaler: textScaler,
       maxLines: 1,
     );
     // TextPainter owns a native paragraph, so it is released even if layout
     // throws.
     try {
       painter.layout();
-      return painter.width;
+      final capHeight = textScaler.scale(textStyle.fontSize ?? 0) *
+          LinagoraSidebarStyle.badgeCapHeightRatio;
+      // Where the baseline leaves the ink centred.
+      final baseline = (pillHeight + capHeight) / 2;
+      final ascent = _paintedAscent(painter);
+      return (
+        width: painter.width,
+        // A counter larger than the pill grows it, and then sits at its top
+        // rather than being pulled up out of the stadium.
+        topInset: math.max(0, baseline - ascent),
+      );
     } finally {
       painter.dispose();
     }
+  }
+
+  /// How far below its box a paragraph puts the baseline it draws on.
+  ///
+  /// The engine may snap that ascent to a whole pixel while
+  /// [LineMetrics.ascent] still reports the font's own — a third of a pixel
+  /// apart at a counter's size. The paragraph's height gives away which.
+  static double _paintedAscent(TextPainter painter) {
+    final line = painter.computeLineMetrics().single;
+    final snapped =
+        (painter.height - (line.ascent + line.descent)).abs() > 0.01;
+    return snapped ? line.ascent.roundToDouble() : line.ascent;
   }
 }

--- a/lib/sidebar/linagora_sidebar_indent.dart
+++ b/lib/sidebar/linagora_sidebar_indent.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+
+/// Carries the accumulated tree indentation down to the sidebar rows below it.
+///
+/// [LinagoraSidebarSubItem] provides it and [LinagoraSidebarItem] consumes it,
+/// so a nested row shifts only its icon and label: the selected and hovered
+/// fill still spans the full sidebar width. Applying indentation around the
+/// row would shorten that fill once per level.
+///
+/// Custom rows can read [of] and apply the returned value to their content
+/// padding.
+class LinagoraSidebarIndent extends InheritedWidget {
+  const LinagoraSidebarIndent({
+    super.key,
+    required this.indent,
+    required super.child,
+  }) : assert(indent >= 0, 'A sidebar indent cannot be negative');
+
+  /// The distance from the sidebar's leading edge to the row's content.
+  final double indent;
+
+  /// The indentation that applies to rows built in [context], or zero outside
+  /// a folder tree.
+  static double of(BuildContext context) {
+    final scope = context
+        .dependOnInheritedWidgetOfExactType<LinagoraSidebarIndent>();
+    return scope?.indent ?? 0;
+  }
+
+  @override
+  bool updateShouldNotify(LinagoraSidebarIndent oldWidget) =>
+      indent != oldWidget.indent;
+}

--- a/lib/sidebar/linagora_sidebar_item.dart
+++ b/lib/sidebar/linagora_sidebar_item.dart
@@ -6,7 +6,6 @@ import 'package:linagora_design_flutter/behaviors/right_click_focus.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_badge.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_indent.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_style.dart';
-import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
 part 'linagora_sidebar_item_content.dart';
 

--- a/lib/sidebar/linagora_sidebar_item.dart
+++ b/lib/sidebar/linagora_sidebar_item.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/behaviors/right_click_focus.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_badge.dart';
+import 'package:linagora_design_flutter/sidebar/linagora_sidebar_indent.dart';
 import 'package:linagora_design_flutter/sidebar/linagora_sidebar_style.dart';
 import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 

--- a/lib/sidebar/linagora_sidebar_item_content.dart
+++ b/lib/sidebar/linagora_sidebar_item_content.dart
@@ -114,11 +114,7 @@ class _SidebarItemRow extends StatelessWidget {
             ),
             if (trailing != null) ...[
               SizedBox(width: style.itemSpacing),
-              _SidebarItemTrailing(
-                color: style.trailingForeground,
-                iconSize: style.itemIconSize,
-                child: trailing!,
-              ),
+              _SidebarItemTrailing(style: style, child: trailing!),
             ],
           ],
         ),
@@ -152,9 +148,8 @@ class _SidebarItemLabel extends StatelessWidget {
             item.label,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: LinagoraTextTheme.material().bodyMedium?.copyWith(
-              color: foregroundColor,
-            ),
+            textHeightBehavior: LinagoraSidebarStyle.middleAligned,
+            style: style.labelTextStyle.copyWith(color: foregroundColor),
           ),
         ),
         if (expanded != null) ...[
@@ -253,22 +248,19 @@ class _SidebarItemChevron extends StatelessWidget {
 }
 
 class _SidebarItemTrailing extends StatelessWidget {
-  const _SidebarItemTrailing({
-    required this.color,
-    required this.iconSize,
-    required this.child,
-  });
+  const _SidebarItemTrailing({required this.style, required this.child});
 
-  final Color color;
-  final double iconSize;
+  final LinagoraSidebarStyle style;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
+    final color = style.trailingForeground;
     return DefaultTextStyle.merge(
-      style: LinagoraTextTheme.material().labelSmall?.copyWith(color: color),
+      style: style.badgeTextStyle.copyWith(color: color),
+      textHeightBehavior: LinagoraSidebarStyle.middleAligned,
       child: IconTheme.merge(
-        data: IconThemeData(color: color, size: iconSize),
+        data: IconThemeData(color: color, size: style.itemIconSize),
         child: child,
       ),
     );

--- a/lib/sidebar/linagora_sidebar_item_content.dart
+++ b/lib/sidebar/linagora_sidebar_item_content.dart
@@ -34,6 +34,9 @@ class _LinagoraSidebarItemContent extends StatelessWidget {
     return Semantics(
       // Text and InkWell already publish the label and button role.
       selected: item.active,
+      // Expanded belongs to the row: a decorative chevron has no semantics,
+      // while a tappable one is a separate control. Leaves have no state.
+      expanded: item.expanded,
       child: Material(
         color: backgroundColor,
         borderRadius: borderRadius,
@@ -86,7 +89,11 @@ class _SidebarItemRow extends StatelessWidget {
       // Minimum, not fixed: the row grows with the text scale.
       constraints: BoxConstraints(minHeight: style.itemMinHeight),
       child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: style.itemHorizontalPadding),
+        // Indent content only, preserving the full-width row background.
+        padding: EdgeInsetsDirectional.only(
+          start: style.itemHorizontalPadding + LinagoraSidebarIndent.of(context),
+          end: style.itemHorizontalPadding,
+        ),
         child: Row(
           children: [
             if (_hasLeading) ...[

--- a/lib/sidebar/linagora_sidebar_style.dart
+++ b/lib/sidebar/linagora_sidebar_style.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
+import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
 /// Design tokens for the shared left menu.
 ///
@@ -45,6 +46,14 @@ class LinagoraSidebarStyle {
   /// the same amount.
   final double disabledOpacity;
 
+  /// Row label, mailbox and folder alike: 14 · w500 · 18.4px line · 0.25
+  /// letter spacing. Carries no colour — the row inks it from its state.
+  final TextStyle labelTextStyle;
+
+  /// Badge counter, and the default for text in the trailing slot:
+  /// 11 · w500 · 16px line · 0.5 letter spacing.
+  final TextStyle badgeTextStyle;
+
   const LinagoraSidebarStyle({
     required this.itemMinHeight,
     required this.itemBorderRadius,
@@ -61,13 +70,16 @@ class LinagoraSidebarStyle {
     required this.foreground,
     required this.activeForeground,
     required this.trailingForeground,
+    required this.labelTextStyle,
+    required this.badgeTextStyle,
     this.disabledOpacity = 0.38,
   });
 
   static final LinagoraSidebarStyle _light = _build(
     overlay: (base: const Color(0xFF1D192B), hover: 0.04, selected: 0.08),
     ink: (
-      normal: const Color(0xFF49494B),
+      // Primary text at 90%, shared by the label and the badge count.
+      normal: const Color(0xFF424244).withValues(alpha: 0.9),
       active: const Color(0xFF0A84FF),
       trailing: const Color(0xFF737576),
     ),
@@ -118,8 +130,36 @@ class LinagoraSidebarStyle {
     foreground: foreground,
     activeForeground: activeForeground,
     trailingForeground: trailingForeground,
+    labelTextStyle: labelTextStyle,
+    badgeTextStyle: badgeTextStyle,
     disabledOpacity: disabledOpacity,
   );
+
+  /// Lays text out on its glyphs, dropping the leading a fixed line height
+  /// adds around them.
+  ///
+  /// Flutter splits that leading in proportion to the font's ascent and
+  /// descent, which leaves the text low in its box. Sidebar labels are single
+  /// lines centred by their row, so the leading only pushes them off centre.
+  static const TextHeightBehavior middleAligned = TextHeightBehavior(
+    applyHeightToFirstAscent: false,
+    applyHeightToLastDescent: false,
+  );
+
+  /// The shared `bodyMedium` token on the sidebar's tighter 18.4px line.
+  static final TextStyle _labelTextStyle = LinagoraTextTheme.material()
+      .bodyMedium!
+      .copyWith(height: 18.4 / 14);
+
+  static final TextStyle _badgeTextStyle =
+      LinagoraTextTheme.material().labelSmall!;
+
+  /// Cap height of TwakeInter (`OS/2.sCapHeight`), and so a digit's ink, as a
+  /// share of the font size.
+  ///
+  /// The badge centres that ink rather than the paragraph around it, which
+  /// reaches lower. Another face costs a fraction of a pixel.
+  static const double badgeCapHeightRatio = 1490 / 2048;
 
   static LinagoraSidebarStyle _build({
     required _Overlay overlay,
@@ -137,11 +177,14 @@ class LinagoraSidebarStyle {
       selectedBackground: selected,
       badgeBackground: selected,
       badgeHeight: LinagoraSpacing.base * 2,
-      badgeHorizontalPadding: LinagoraSpacing.base * 0.75,
+      // Off the 8px scale: it is what hugs `999+` to a 39px pill.
+      badgeHorizontalPadding: 4.5,
       badgeForeground: ink.normal,
       foreground: ink.normal,
       activeForeground: ink.active,
       trailingForeground: ink.trailing,
+      labelTextStyle: _labelTextStyle,
+      badgeTextStyle: _badgeTextStyle,
     );
   }
 }
@@ -168,5 +211,7 @@ typedef _SidebarStyleValues = ({
   Color foreground,
   Color activeForeground,
   Color trailingForeground,
+  TextStyle labelTextStyle,
+  TextStyle badgeTextStyle,
   double disabledOpacity,
 });

--- a/lib/sidebar/linagora_sidebar_sub_item.dart
+++ b/lib/sidebar/linagora_sidebar_sub_item.dart
@@ -1,0 +1,74 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/sidebar/linagora_sidebar_indent.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
+
+/// Indents one [child] below a sidebar folder.
+///
+/// The indentation is published through [LinagoraSidebarIndent] rather than
+/// applied as padding, so the child row keeps the full sidebar width and only
+/// its content moves. Nesting accumulates: a sub-item inside another sub-item
+/// adds to the indentation already in scope.
+///
+/// Only a row that reads [LinagoraSidebarIndent] moves — [LinagoraSidebarItem]
+/// does. A child that ignores it, such as a bare `Text` or a product's own row
+/// widget, renders flush against the sidebar edge; read
+/// [LinagoraSidebarIndent.of] in that row and inset its content the same way.
+///
+/// [LinagoraSidebarTreeList] applies this to its entries already, so reach for
+/// it directly only in a custom tree layout. Icons remain the child item's
+/// responsibility, so hidden product icons can be enabled later with no
+/// tree-layout change.
+class LinagoraSidebarSubItem extends StatelessWidget {
+  static const double defaultIndent = LinagoraSpacing.base;
+
+  const LinagoraSidebarSubItem({
+    super.key,
+    required this.child,
+    this.depth = 1,
+    this.indent = defaultIndent,
+    this.maxIndent,
+  }) : assert(depth > 0, 'A sidebar sub-item must have a positive depth'),
+       assert(indent >= 0, 'A sidebar sub-item indent cannot be negative'),
+       assert(
+         maxIndent == null || maxIndent >= 0,
+         'A sidebar sub-item maximum indent cannot be negative',
+       );
+
+  final Widget child;
+
+  /// How many levels to indent by at once.
+  ///
+  /// Leave it at `1` when a custom tree is built by nesting: each level wraps
+  /// the one below it, so the levels already add up.
+  ///
+  /// Set it when the tree is *flattened* into a `ListView.builder`, where
+  /// every row is a sibling and carries its own level. Prefer that shape for a
+  /// mailbox with many folders because only visible rows are built.
+  ///
+  /// Do not combine the two — a `depth` above `1` inside a nested tree indents
+  /// on top of the levels already in scope.
+  final int depth;
+
+  /// Horizontal space added per level of [depth].
+  final double indent;
+
+  /// Caps the total accumulated indentation when supplied.
+  ///
+  /// Use it for a tree whose depth can grow without bound, so a narrow sidebar
+  /// keeps enough room for every row's icon and label.
+  final double? maxIndent;
+
+  @override
+  Widget build(BuildContext context) {
+    final accumulatedIndent =
+        LinagoraSidebarIndent.of(context) + depth * indent;
+    return LinagoraSidebarIndent(
+      indent: maxIndent == null
+          ? accumulatedIndent
+          : math.min(accumulatedIndent, maxIndent!),
+      child: child,
+    );
+  }
+}

--- a/lib/sidebar/linagora_sidebar_tree_list.dart
+++ b/lib/sidebar/linagora_sidebar_tree_list.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/sidebar/linagora_sidebar_sub_item.dart';
+
+/// Builds one row from a visible [LinagoraSidebarTreeListEntry].
+typedef LinagoraSidebarTreeListItemBuilder<T> = Widget Function(
+  BuildContext context,
+  LinagoraSidebarTreeListEntry<T> entry,
+);
+
+/// Data for one visible row in [LinagoraSidebarTreeList].
+///
+/// The application flattens its folder hierarchy and omits descendants of
+/// collapsed folders before passing entries to the list. [id] must be unique
+/// within that visible list so Flutter can retain the row's element when a
+/// sibling is inserted, removed, or reordered.
+class LinagoraSidebarTreeListEntry<T> {
+  const LinagoraSidebarTreeListEntry({
+    required this.id,
+    required this.data,
+    this.depth = 0,
+  }) : assert(depth >= 0, 'A sidebar tree list depth cannot be negative');
+
+  /// Stable application identifier for this row.
+  final Object id;
+
+  /// Product data consumed by [LinagoraSidebarTreeList.itemBuilder].
+  final T data;
+
+  /// Zero for a root row, then one for each nesting level below it.
+  final int depth;
+}
+
+/// A virtualized, flattened sidebar tree for production-sized folder lists.
+///
+/// This widget deliberately does not own expansion state or traverse a node
+/// hierarchy. The product owns its expanded folder IDs, derives [entries] from
+/// them, and rebuilds the list after a disclosure toggle. As a result the
+/// state survives route changes, tabs, and restoration when the product
+/// persists it, while [ListView.builder] creates only rows near the viewport.
+///
+/// Give this widget a [PageStorageKey] to restore its scroll offset while its
+/// surrounding [PageStorage] bucket remains alive, or provide [controller]
+/// when the product needs to own and restore the offset itself. It must be in
+/// a bounded vertical region, for example an [Expanded] or [SizedBox].
+class LinagoraSidebarTreeList<T> extends StatelessWidget {
+  /// The maximum content indentation used by default for deep folder trees.
+  static const double defaultMaxIndent =
+      LinagoraSidebarSubItem.defaultIndent * 8;
+
+  LinagoraSidebarTreeList({
+    super.key,
+    required this.entries,
+    required this.itemBuilder,
+    this.controller,
+    this.padding = EdgeInsets.zero,
+    this.physics,
+    this.primary,
+    this.cacheExtent,
+    this.indent = LinagoraSidebarSubItem.defaultIndent,
+    this.maxIndent = defaultMaxIndent,
+  }) : assert(indent >= 0, 'A sidebar tree list indent cannot be negative'),
+       assert(
+         maxIndent >= 0,
+         'A sidebar tree list maximum indent cannot be negative',
+       ),
+       assert(
+         _hasUniqueEntryIds(entries),
+         'A sidebar tree list needs unique entry IDs',
+       );
+
+  /// The already-visible tree rows, in their visual order.
+  final List<LinagoraSidebarTreeListEntry<T>> entries;
+
+  /// Builds the actual row, normally a [LinagoraSidebarItem].
+  final LinagoraSidebarTreeListItemBuilder<T> itemBuilder;
+
+  /// Lets the product read, restore, or programmatically move the list.
+  final ScrollController? controller;
+
+  final EdgeInsetsGeometry padding;
+
+  final ScrollPhysics? physics;
+
+  final bool? primary;
+
+  final double? cacheExtent;
+
+  /// Horizontal content indentation added for every [depth] level.
+  final double indent;
+
+  /// Maximum accumulated content indentation for a nested row.
+  ///
+  /// Folder protocols allow arbitrary depths, but a fixed-width sidebar must
+  /// preserve enough room for row content. Increase this when the host sidebar
+  /// is wider, lower it for a more compact hierarchy, or pass
+  /// [double.infinity] when the host guarantees a bounded depth and wants
+  /// every level to stay distinguishable.
+  final double maxIndent;
+
+  /// Maps a row key back to its position so the sliver can move an existing
+  /// element instead of rebuilding it. It is created lazily when Flutter
+  /// updates keyed children.
+  late final Map<Object, int> _indexById = {
+    for (var index = 0; index < entries.length; index++)
+      entries[index].id: index,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    // [key] identifies this widget and must not be repeated on the list it
+    // builds: a GlobalKey would then be claimed twice and throw. A
+    // PageStorageKey still reaches the scroll position from up here.
+    return ListView.builder(
+      controller: controller,
+      padding: padding,
+      physics: physics,
+      primary: primary,
+      cacheExtent: cacheExtent,
+      itemCount: entries.length,
+      itemBuilder: _buildEntry,
+      findChildIndexCallback: _findEntryIndex,
+    );
+  }
+
+  /// Without this the sliver matches children by index alone, so inserting or
+  /// removing one row rebuilds every row after it from scratch — losing hover,
+  /// focus and any state a product row holds — even though each carries a
+  /// stable key.
+  int? _findEntryIndex(Key key) {
+    if (key is! ValueKey<Object>) return null;
+    return _indexById[key.value];
+  }
+
+  Widget _buildEntry(BuildContext context, int index) {
+    final entry = entries[index];
+    final row = itemBuilder(context, entry);
+    final rowKey = ValueKey<Object>(entry.id);
+
+    if (entry.depth == 0) {
+      return KeyedSubtree(key: rowKey, child: row);
+    }
+
+    return LinagoraSidebarSubItem(
+      key: rowKey,
+      depth: entry.depth,
+      indent: indent,
+      maxIndent: maxIndent,
+      child: row,
+    );
+  }
+
+  static bool _hasUniqueEntryIds<T>(
+    List<LinagoraSidebarTreeListEntry<T>> entries,
+  ) {
+    final ids = <Object>{};
+    return entries.every((entry) => ids.add(entry.id));
+  }
+}

--- a/test/sidebar/linagora_sidebar_ink_test.dart
+++ b/test/sidebar/linagora_sidebar_ink_test.dart
@@ -7,11 +7,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
-/// Where a row's text lands, rather than where its box does.
+/// Where the badge's count lands, rather than where its box does.
 ///
-/// A paragraph is taller than the glyphs inside it and hangs lower, so lining
-/// boxes up left the count low in its pill and the label low against its
-/// chevron. These render with the shipped font and read the painted pixels.
+/// The count is placed by arithmetic on the font's metrics, so nothing but
+/// the painted pixels can confirm it. These render with the shipped font and
+/// read them. Boxes are checked in `linagora_sidebar_typography_test.dart`.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -20,7 +20,6 @@ void main() {
   test('measures the shipped font, not a stand-in', _fontIsTwakeInter);
   testWidgets('centres a full count in its pill', _countIsCentred('999+'));
   testWidgets('centres a single digit in its pill', _countIsCentred('3'));
-  testWidgets('lines the label up with its chevron', _labelMeetsTheChevron);
 }
 
 /// These tests turn on the real font's metrics, and the test font's are
@@ -39,18 +38,15 @@ void _fontIsTwakeInter() {
   painter.dispose();
 }
 
-/// As close as antialiasing lets two edges be read.
-const _tolerance = 0.13;
+/// Room for one ink row at either edge, which is where rasterizers differ
+/// across platforms. The drift this guards against is three times as wide.
+const _tolerance = 0.25;
 
 const _pixelRatio = 8.0;
 
 WidgetTesterCallback _countIsCentred(String label) {
   return (tester) async {
-    final pixels = await _render(
-      tester,
-      LinagoraSidebarBadge(label: label),
-      padding: 4,
-    );
+    final pixels = await _renderBadge(tester, label);
     final pill = pixels.inkRows(250);
     final ink = pixels.inkRows(140);
 
@@ -69,39 +65,7 @@ WidgetTesterCallback _countIsCentred(String label) {
   };
 }
 
-/// A chevron sits on the label's line, not on the paragraph around it.
-///
-/// The chevron is read as a box, not as ink: an icon font centres its glyph in
-/// the square it is given, and the stand-in glyph a test renders does not.
-Future<void> _labelMeetsTheChevron(WidgetTester tester) async {
-  const label = 'Personal folders';
-  final pixels = await _render(
-    tester,
-    const SizedBox(
-      width: 220,
-      child: LinagoraSidebarItem(
-        label: label,
-        icon: Icons.folder_outlined,
-        expanded: true,
-      ),
-    ),
-  );
-
-  final labelInk = pixels.inkRows(150, within: find.text(label));
-  final chevron = pixels.middleOf(find.byIcon(Icons.keyboard_arrow_down));
-
-  expect(
-    pixels.centreOf(labelInk),
-    closeTo(chevron, _tolerance),
-    reason: 'the label and the chevron are on different lines',
-  );
-}
-
-Future<_Pixels> _render(
-  WidgetTester tester,
-  Widget child, {
-  double padding = 0,
-}) async {
+Future<_Pixels> _renderBadge(WidgetTester tester, String label) async {
   final key = GlobalKey();
   await tester.pumpWidget(
     MaterialApp(
@@ -109,13 +73,14 @@ Future<_Pixels> _render(
         body: Center(
           child: RepaintBoundary(
             key: key,
-            // Opaque, so the paint reads as plain darkness rather than as
-            // alpha over nothing.
+            // Opaque, so the paint reads as darkness rather than as alpha
+            // over nothing.
             child: ColoredBox(
               color: const Color(0xFFFFFFFF),
+              // Room around the pill, so its own edge is never the first row.
               child: Padding(
-                padding: EdgeInsets.all(padding),
-                child: child,
+                padding: const EdgeInsets.all(4),
+                child: LinagoraSidebarBadge(label: label),
               ),
             ),
           ),
@@ -132,8 +97,6 @@ Future<_Pixels> _render(
     () => image.toByteData(format: ui.ImageByteFormat.rawRgba),
   ))!;
   final pixels = _Pixels(
-    tester: tester,
-    origin: tester.getRect(find.byKey(key)).topLeft,
     width: image.width,
     height: image.height,
     rgba: data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
@@ -156,54 +119,28 @@ Future<void> _loadTwakeInter() async {
 
 class _Pixels {
   const _Pixels({
-    required this.tester,
-    required this.origin,
     required this.width,
     required this.height,
     required this.rgba,
   });
 
-  final WidgetTester tester;
-
-  /// Where the captured image starts, so a widget's rect can be read in it.
-  final Offset origin;
-
   final int width;
   final int height;
   final Uint8List rgba;
 
-  /// The rows holding anything darker than [red], top and bottom included, and
-  /// optionally only across the columns a [within] widget occupies.
-  List<int> inkRows(int red, {Finder? within}) {
-    final columns = within == null
-        ? (from: 0, to: width)
-        : _columnsOf(tester.getRect(within));
+  /// The rows holding anything darker than [red], top and bottom included.
+  List<int> inkRows(int red) {
     final rows = [
       for (var y = 0; y < height; y++)
-        if (_darkestInRow(y, columns.from, columns.to) < red) y,
+        if (_darkestInRow(y) < red) y,
     ];
     expect(rows, isNotEmpty, reason: 'nothing was painted below $red');
     return rows;
   }
 
-  /// The middle of a run of rows, in logical pixels down the image.
-  double centreOf(List<int> rows) => (rows.first + rows.last) / 2 / _pixelRatio;
-
-  /// The middle of a widget's box, in the same logical pixels.
-  double middleOf(Finder finder) =>
-      tester.getRect(finder).center.dy - origin.dy;
-
-  ({int from, int to}) _columnsOf(Rect rect) {
-    final local = rect.shift(-origin);
-    return (
-      from: (local.left * _pixelRatio).floor().clamp(0, width),
-      to: (local.right * _pixelRatio).ceil().clamp(0, width),
-    );
-  }
-
-  int _darkestInRow(int y, int from, int to) {
+  int _darkestInRow(int y) {
     var darkest = 255;
-    for (var x = from; x < to; x++) {
+    for (var x = 0; x < width; x++) {
       final pixel = (y * width + x) * 4;
       // A boundary whose width does not land on a whole device pixel leaves
       // the last column unpainted, and unpainted reads as black.

--- a/test/sidebar/linagora_sidebar_ink_test.dart
+++ b/test/sidebar/linagora_sidebar_ink_test.dart
@@ -1,0 +1,216 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+/// Where a row's text lands, rather than where its box does.
+///
+/// A paragraph is taller than the glyphs inside it and hangs lower, so lining
+/// boxes up left the count low in its pill and the label low against its
+/// chevron. These render with the shipped font and read the painted pixels.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(_loadTwakeInter);
+
+  test('measures the shipped font, not a stand-in', _fontIsTwakeInter);
+  testWidgets('centres a full count in its pill', _countIsCentred('999+'));
+  testWidgets('centres a single digit in its pill', _countIsCentred('3'));
+  testWidgets('lines the label up with its chevron', _labelMeetsTheChevron);
+}
+
+/// These tests turn on the real font's metrics, and the test font's are
+/// symmetric enough to hide the drift they exist to catch. `999+` is 30px
+/// wide in the design.
+void _fontIsTwakeInter() {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: LinagoraSidebarBadge.widestLabel,
+      style: LinagoraSidebarStyle.light().badgeTextStyle,
+    ),
+    textDirection: TextDirection.ltr,
+  )..layout();
+
+  expect(painter.width, closeTo(30, 1));
+  painter.dispose();
+}
+
+/// As close as antialiasing lets two edges be read.
+const _tolerance = 0.13;
+
+const _pixelRatio = 8.0;
+
+WidgetTesterCallback _countIsCentred(String label) {
+  return (tester) async {
+    final pixels = await _render(
+      tester,
+      LinagoraSidebarBadge(label: label),
+      padding: 4,
+    );
+    final pill = pixels.inkRows(250);
+    final ink = pixels.inkRows(140);
+
+    // The pill is the only reference the eye has, so the gaps come off it
+    // rather than off the widget's bounds.
+    final scale =
+        (pill.last - pill.first + 1) / LinagoraSidebarStyle.light().badgeHeight;
+    final above = (ink.first - pill.first) / scale;
+    final below = (pill.last - ink.last) / scale;
+
+    expect(
+      above,
+      closeTo(below, _tolerance),
+      reason: '"$label" sits off centre',
+    );
+  };
+}
+
+/// A chevron sits on the label's line, not on the paragraph around it.
+///
+/// The chevron is read as a box, not as ink: an icon font centres its glyph in
+/// the square it is given, and the stand-in glyph a test renders does not.
+Future<void> _labelMeetsTheChevron(WidgetTester tester) async {
+  const label = 'Personal folders';
+  final pixels = await _render(
+    tester,
+    const SizedBox(
+      width: 220,
+      child: LinagoraSidebarItem(
+        label: label,
+        icon: Icons.folder_outlined,
+        expanded: true,
+      ),
+    ),
+  );
+
+  final labelInk = pixels.inkRows(150, within: find.text(label));
+  final chevron = pixels.middleOf(find.byIcon(Icons.keyboard_arrow_down));
+
+  expect(
+    pixels.centreOf(labelInk),
+    closeTo(chevron, _tolerance),
+    reason: 'the label and the chevron are on different lines',
+  );
+}
+
+Future<_Pixels> _render(
+  WidgetTester tester,
+  Widget child, {
+  double padding = 0,
+}) async {
+  final key = GlobalKey();
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: RepaintBoundary(
+            key: key,
+            // Opaque, so the paint reads as plain darkness rather than as
+            // alpha over nothing.
+            child: ColoredBox(
+              color: const Color(0xFFFFFFFF),
+              child: Padding(
+                padding: EdgeInsets.all(padding),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  final boundary =
+      key.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  final image =
+      (await tester.runAsync(() => boundary.toImage(pixelRatio: _pixelRatio)))!;
+  final data = (await tester.runAsync(
+    () => image.toByteData(format: ui.ImageByteFormat.rawRgba),
+  ))!;
+  final pixels = _Pixels(
+    tester: tester,
+    origin: tester.getRect(find.byKey(key)).topLeft,
+    width: image.width,
+    height: image.height,
+    rgba: data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+  );
+  image.dispose();
+  return pixels;
+}
+
+Future<void> _loadTwakeInter() async {
+  final loader = FontLoader('packages/linagora_design_flutter/TwakeInter');
+  loader.addFont(
+    Future.value(
+      File(
+        'assets/fonts/TwakeInter-Medium.ttf',
+      ).readAsBytesSync().buffer.asByteData(),
+    ),
+  );
+  await loader.load();
+}
+
+class _Pixels {
+  const _Pixels({
+    required this.tester,
+    required this.origin,
+    required this.width,
+    required this.height,
+    required this.rgba,
+  });
+
+  final WidgetTester tester;
+
+  /// Where the captured image starts, so a widget's rect can be read in it.
+  final Offset origin;
+
+  final int width;
+  final int height;
+  final Uint8List rgba;
+
+  /// The rows holding anything darker than [red], top and bottom included, and
+  /// optionally only across the columns a [within] widget occupies.
+  List<int> inkRows(int red, {Finder? within}) {
+    final columns = within == null
+        ? (from: 0, to: width)
+        : _columnsOf(tester.getRect(within));
+    final rows = [
+      for (var y = 0; y < height; y++)
+        if (_darkestInRow(y, columns.from, columns.to) < red) y,
+    ];
+    expect(rows, isNotEmpty, reason: 'nothing was painted below $red');
+    return rows;
+  }
+
+  /// The middle of a run of rows, in logical pixels down the image.
+  double centreOf(List<int> rows) => (rows.first + rows.last) / 2 / _pixelRatio;
+
+  /// The middle of a widget's box, in the same logical pixels.
+  double middleOf(Finder finder) =>
+      tester.getRect(finder).center.dy - origin.dy;
+
+  ({int from, int to}) _columnsOf(Rect rect) {
+    final local = rect.shift(-origin);
+    return (
+      from: (local.left * _pixelRatio).floor().clamp(0, width),
+      to: (local.right * _pixelRatio).ceil().clamp(0, width),
+    );
+  }
+
+  int _darkestInRow(int y, int from, int to) {
+    var darkest = 255;
+    for (var x = from; x < to; x++) {
+      final pixel = (y * width + x) * 4;
+      // A boundary whose width does not land on a whole device pixel leaves
+      // the last column unpainted, and unpainted reads as black.
+      if (rgba[pixel + 3] < 250) continue;
+      final red = rgba[pixel];
+      if (red < darkest) darkest = red;
+    }
+    return darkest;
+  }
+}

--- a/test/sidebar/linagora_sidebar_item_state_test.dart
+++ b/test/sidebar/linagora_sidebar_item_state_test.dart
@@ -19,6 +19,7 @@ void main() {
   testWidgets('pins hover when hovered is true', _hoverForced);
   testWidgets('dims every slot of a disabled row', _disabledDimsUniformly);
   testWidgets('publishes the selected state to semantics', _semanticsSelected);
+  testWidgets('publishes folder expansion to semantics', _semanticsExpansion);
   testWidgets('honours the colour overrides', _colourOverrides);
   testWidgets('lets an injected style beat the ambient theme', _styleOverride);
   testWidgets('resolves dark tokens from the ambient theme', _darkTokens);
@@ -164,6 +165,30 @@ Future<void> _semanticsSelected(WidgetTester tester) async {
         hasFocusAction: true,
       ),
     );
+  } finally {
+    handle.dispose();
+  }
+}
+
+Future<void> _semanticsExpansion(WidgetTester tester) async {
+  final handle = tester.ensureSemantics();
+  try {
+    for (final expanded in <bool?>[true, false, null]) {
+      await pumpSidebarItem(
+        tester,
+        LinagoraSidebarItem(label: 'Folders', expanded: expanded),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(LinagoraSidebarItem)),
+        matchesSemantics(
+          hasExpandedState: expanded != null,
+          isExpanded: expanded ?? false,
+          hasSelectedState: true,
+          isSelected: false,
+        ),
+      );
+    }
   } finally {
     handle.dispose();
   }

--- a/test/sidebar/linagora_sidebar_item_style_test.dart
+++ b/test/sidebar/linagora_sidebar_item_style_test.dart
@@ -98,7 +98,7 @@ Future<void> _textScale(WidgetTester tester) async {
   await tester.pumpWidget(
     const MaterialApp(
       home: MediaQuery(
-        data: MediaQueryData(textScaler: TextScaler.linear(2.5)),
+        data: MediaQueryData(textScaler: TextScaler.linear(3)),
         child: Scaffold(
           body: SizedBox(
             width: 204,
@@ -114,10 +114,15 @@ Future<void> _textScale(WidgetTester tester) async {
   );
 
   expect(tester.takeException(), isNull);
+
+  // The row is laid out on the label's glyphs, so it follows the text once
+  // they outgrow the minimum — which is the premise this asserts first.
+  final minHeight = LinagoraSidebarStyle.light().itemMinHeight;
   expect(
-    tester.getSize(sidebarRowFinder).height,
-    greaterThan(LinagoraSidebarStyle.light().itemMinHeight),
+    tester.getSize(find.text('Action required')).height,
+    greaterThan(minHeight),
   );
+  expect(tester.getSize(sidebarRowFinder).height, greaterThan(minHeight));
 }
 
 Future<void> _trailingIsMuted(WidgetTester tester) async {
@@ -245,6 +250,8 @@ LinagoraSidebarStyle _styleWithSpacing(double itemSpacing) {
     foreground: style.foreground,
     activeForeground: style.activeForeground,
     trailingForeground: style.trailingForeground,
+    labelTextStyle: style.labelTextStyle,
+    badgeTextStyle: style.badgeTextStyle,
     disabledOpacity: style.disabledOpacity,
   );
 }

--- a/test/sidebar/linagora_sidebar_tree_list_scroll_test.dart
+++ b/test/sidebar/linagora_sidebar_tree_list_scroll_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+import 'linagora_sidebar_tree_list_test_utils.dart';
+
+void main() {
+  testWidgets('builds only rows near the viewport', _buildsVisibleRows);
+  testWidgets('forwards scroll ownership to the list', _forwardsScrollOwnership);
+  testWidgets('accepts a GlobalKey without claiming it twice', _acceptsAGlobalKey);
+  testWidgets('keeps row elements when a sibling is inserted above', _keepsRowElementsOnInsert);
+  testWidgets('restores its scroll offset from page storage', _restoresScrollOffset);
+}
+
+Future<void> _buildsVisibleRows(WidgetTester tester) async {
+  var buildCount = 0;
+  final entries = List.generate(
+    200,
+    (index) => LinagoraSidebarTreeListEntry(
+      id: index,
+      data: 'Folder $index',
+    ),
+  );
+
+  await pumpSidebarTreeList(
+    tester,
+    Align(
+      alignment: Alignment.topLeft,
+      child: SizedBox(
+        height: 72,
+        child: LinagoraSidebarTreeList<String>(
+          entries: entries,
+          itemBuilder: (_, entry) {
+            buildCount++;
+            return SizedBox(height: 36, child: Text(entry.data));
+          },
+        ),
+      ),
+    ),
+  );
+
+  expect(buildCount, lessThan(entries.length));
+  expect(tester.getRect(find.byType(ListView)).height, 72);
+  expect(find.text('Folder 199'), findsNothing);
+}
+
+Future<void> _forwardsScrollOwnership(WidgetTester tester) async {
+  final controller = ScrollController();
+  addTearDown(controller.dispose);
+  const key = PageStorageKey('folder-tree-list');
+
+  await pumpSidebarTreeList(
+    tester,
+    LinagoraSidebarTreeList<String>(
+      key: key,
+      controller: controller,
+      entries: const [
+        LinagoraSidebarTreeListEntry(id: 'personal', data: 'Personal folders'),
+      ],
+      itemBuilder: sidebarTreeListFolderItem,
+    ),
+  );
+
+  final list = tester.widget<ListView>(find.byType(ListView));
+  expect(list.controller, same(controller));
+  // The key stays on the tree list alone. Repeating it on the list it builds
+  // makes a GlobalKey throw, and buys nothing: page storage reaches the scroll
+  // position through any ancestor key.
+  expect(list.key, isNull);
+  expect(find.byKey(key), findsOneWidget);
+}
+
+/// A GlobalKey may only be claimed by one widget, so the tree list must not
+/// hand its own key to the list it builds.
+Future<void> _acceptsAGlobalKey(WidgetTester tester) async {
+  await pumpSidebarTreeList(
+    tester,
+    LinagoraSidebarTreeList<String>(
+      key: GlobalKey(),
+      entries: const [
+        LinagoraSidebarTreeListEntry(id: 'personal', data: 'Personal folders'),
+      ],
+      itemBuilder: sidebarTreeListFolderItem,
+    ),
+  );
+
+  expect(tester.takeException(), isNull);
+  expect(find.text('Personal folders'), findsOneWidget);
+}
+
+/// Expanding a folder inserts rows above existing ones. Those existing rows
+/// carry stable IDs, so their elements have to move rather than be rebuilt,
+/// or every row below a toggle loses hover, focus and product row state.
+Future<void> _keepsRowElementsOnInsert(WidgetTester tester) async {
+  Future<void> pump(List<String> ids) {
+    return pumpSidebarTreeList(
+      tester,
+      LinagoraSidebarTreeList<String>(
+        entries: [
+          for (final id in ids)
+            LinagoraSidebarTreeListEntry(id: id, data: id),
+        ],
+        itemBuilder: (_, entry) => _LifecycleRow(label: entry.data),
+      ),
+    );
+  }
+
+  await pump(['a', 'b', 'c']);
+  expect(_LifecycleRowState.built, ['a', 'b', 'c']);
+
+  _LifecycleRowState.built.clear();
+  await pump(['inserted', 'a', 'b', 'c']);
+
+  expect(_LifecycleRowState.built, ['inserted']);
+}
+
+/// Reports every row that is created from scratch, so a test can tell a moved
+/// element from a rebuilt one.
+class _LifecycleRow extends StatefulWidget {
+  const _LifecycleRow({required this.label});
+
+  final String label;
+
+  @override
+  State<_LifecycleRow> createState() => _LifecycleRowState();
+}
+
+class _LifecycleRowState extends State<_LifecycleRow> {
+  static final List<String> built = <String>[];
+
+  @override
+  void initState() {
+    super.initState();
+    built.add(widget.label);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(height: 36, child: Text(widget.label));
+  }
+}
+
+Future<void> _restoresScrollOffset(WidgetTester tester) async {
+  final bucket = PageStorageBucket();
+  const key = PageStorageKey<String>('folder-tree-list');
+  await pumpSidebarTreeList(
+    tester,
+    PageStorage(bucket: bucket, child: _scrollableTreeList(key)),
+  );
+
+  await tester.drag(find.byType(ListView), const Offset(0, -240));
+  await tester.pumpAndSettle();
+  final offset = _scrollOffset(tester);
+  expect(offset, greaterThan(0));
+
+  await pumpSidebarTreeList(tester, const SizedBox());
+  await pumpSidebarTreeList(
+    tester,
+    PageStorage(bucket: bucket, child: _scrollableTreeList(key)),
+  );
+
+  expect(_scrollOffset(tester), closeTo(offset, 0.1));
+}
+
+Widget _scrollableTreeList(Key key) {
+  return LinagoraSidebarTreeList<String>(
+    key: key,
+    entries: List.generate(
+      100,
+      (index) => LinagoraSidebarTreeListEntry(
+        id: index,
+        data: 'Folder $index',
+      ),
+    ),
+    itemBuilder: (_, entry) => SizedBox(height: 36, child: Text(entry.data)),
+  );
+}
+
+double _scrollOffset(WidgetTester tester) {
+  return tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels;
+}

--- a/test/sidebar/linagora_sidebar_tree_list_test.dart
+++ b/test/sidebar/linagora_sidebar_tree_list_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+import 'linagora_sidebar_tree_list_test_utils.dart';
+
+void main() {
+  testWidgets('indents flattened child content without shrinking its row', _indentsChildContent);
+  testWidgets('indents custom depths from the trailing edge in right-to-left locales', _indentsRightToLeft);
+  testWidgets('caps deep indentation to preserve row content', _capsDeepIndent);
+  testWidgets('lets the application control visible descendants', _usesApplicationExpansion);
+  test('rejects invalid tree list dimensions', _rejectsInvalidDimensions);
+}
+
+Future<void> _indentsChildContent(WidgetTester tester) async {
+  await pumpSidebarTreeList(
+    tester,
+    LinagoraSidebarTreeList<String>(
+      entries: const [
+        LinagoraSidebarTreeListEntry(id: 'personal', data: 'Personal folders'),
+        LinagoraSidebarTreeListEntry(
+          id: 'project',
+          data: 'Project',
+          depth: 1,
+        ),
+        LinagoraSidebarTreeListEntry(
+          id: 'archive',
+          data: 'Archive',
+          depth: 3,
+        ),
+      ],
+      itemBuilder: sidebarTreeListFolderItem,
+    ),
+  );
+
+  final folderLabel = tester.getRect(find.text('Personal folders'));
+  final childLabel = tester.getRect(find.text('Project'));
+
+  expect(
+    childLabel.left - folderLabel.left,
+    LinagoraSidebarSubItem.defaultIndent,
+  );
+  final folderRow = sidebarTreeListRowRect(tester, 'Personal folders');
+  final childRow = sidebarTreeListRowRect(tester, 'Project');
+  expect(childRow.left, folderRow.left);
+  expect(childRow.width, folderRow.width);
+  expect(
+    tester.getRect(find.text('Archive')).left - folderLabel.left,
+    3 * LinagoraSidebarSubItem.defaultIndent,
+  );
+  expect(find.byKey(const ValueKey<Object>('project')), findsOneWidget);
+}
+
+Future<void> _indentsRightToLeft(WidgetTester tester) async {
+  const indent = 12.0;
+  await pumpSidebarTreeList(
+    tester,
+    Directionality(
+      textDirection: TextDirection.rtl,
+      child: LinagoraSidebarTreeList<String>(
+        indent: indent,
+        entries: const [
+          LinagoraSidebarTreeListEntry(
+            id: 'personal',
+            data: 'Personal folders',
+          ),
+          LinagoraSidebarTreeListEntry(
+            id: 'project',
+            data: 'Project',
+            depth: 1,
+          ),
+        ],
+        itemBuilder: sidebarTreeListFolderItem,
+      ),
+    ),
+  );
+
+  final folderLabel = tester.getRect(find.text('Personal folders'));
+  final childLabel = tester.getRect(find.text('Project'));
+
+  expect(
+    folderLabel.right - childLabel.right,
+    indent,
+  );
+}
+
+/// Folder protocols allow unbounded nesting while the sidebar keeps a fixed
+/// width. Uncapped, `depth * indent` pushed the leading icon out of a 204px row
+/// and it overflowed, so the indent has to flatten instead of growing.
+Future<void> _capsDeepIndent(WidgetTester tester) async {
+  await pumpSidebarTreeList(
+    tester,
+    LinagoraSidebarTreeList<String>(
+      entries: const [
+        LinagoraSidebarTreeListEntry(id: 'personal', data: 'Personal folders'),
+        LinagoraSidebarTreeListEntry(
+          id: 'archive',
+          data: 'Archive',
+          depth: 20,
+        ),
+      ],
+      itemBuilder: sidebarTreeListFolderItem,
+    ),
+  );
+
+  final folderLabel = tester.getRect(find.text('Personal folders'));
+  final deepLabel = tester.getRect(find.text('Archive'));
+
+  expect(
+    deepLabel.left - folderLabel.left,
+    LinagoraSidebarTreeList.defaultMaxIndent,
+  );
+  expect(tester.takeException(), isNull);
+}
+
+Future<void> _usesApplicationExpansion(WidgetTester tester) async {
+  await pumpSidebarTreeList(tester, const _ControlledTreeList());
+
+  expect(find.text('Project'), findsNothing);
+
+  await tester.tap(find.byIcon(Icons.keyboard_arrow_right));
+  await tester.pump();
+
+  expect(find.text('Project'), findsOneWidget);
+
+  await tester.tap(find.byIcon(Icons.keyboard_arrow_down));
+  await tester.pump();
+
+  expect(find.text('Project'), findsNothing);
+}
+
+void _rejectsInvalidDimensions() {
+  expect(
+    () => LinagoraSidebarTreeListEntry(
+      id: 'folder',
+      data: 'Folder',
+      depth: -1,
+    ),
+    throwsAssertionError,
+  );
+  expect(
+    () => LinagoraSidebarTreeList<String>(
+      entries: const [
+        LinagoraSidebarTreeListEntry(id: 'folder', data: 'First'),
+        LinagoraSidebarTreeListEntry(id: 'folder', data: 'Second'),
+      ],
+      itemBuilder: (_, entry) => Text(entry.data),
+    ),
+    throwsAssertionError,
+  );
+  expect(
+    () => LinagoraSidebarTreeList<String>(
+      entries: const [],
+      indent: -1,
+      itemBuilder: (_, entry) => Text(entry.data),
+    ),
+    throwsAssertionError,
+  );
+  expect(
+    () => LinagoraSidebarTreeList<String>(
+      entries: const [],
+      maxIndent: -1,
+      itemBuilder: (_, entry) => Text(entry.data),
+    ),
+    throwsAssertionError,
+  );
+  expect(
+    () => LinagoraSidebarSubItem(depth: 0, child: const SizedBox()),
+    throwsAssertionError,
+  );
+}
+
+class _ControlledTreeList extends StatefulWidget {
+  const _ControlledTreeList();
+
+  @override
+  State<_ControlledTreeList> createState() => _ControlledTreeListState();
+}
+
+class _ControlledTreeListState extends State<_ControlledTreeList> {
+  bool _personalFoldersExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return LinagoraSidebarTreeList<String>(
+      entries: [
+        const LinagoraSidebarTreeListEntry(
+          id: 'personal',
+          data: 'Personal folders',
+        ),
+        if (_personalFoldersExpanded)
+          const LinagoraSidebarTreeListEntry(
+            id: 'project',
+            data: 'Project',
+            depth: 1,
+          ),
+      ],
+      itemBuilder: _buildFolder,
+    );
+  }
+
+  Widget _buildFolder(
+    BuildContext context,
+    LinagoraSidebarTreeListEntry<String> entry,
+  ) {
+    final isPersonalFolders = entry.id == 'personal';
+    return LinagoraSidebarItem(
+      label: entry.data,
+      icon: Icons.folder_outlined,
+      expanded: isPersonalFolders ? _personalFoldersExpanded : null,
+      onExpandToggle: isPersonalFolders ? _togglePersonalFolders : null,
+      expandToggleLabel: isPersonalFolders
+          ? (_personalFoldersExpanded ? 'Collapse folders' : 'Expand folders')
+          : null,
+    );
+  }
+
+  void _togglePersonalFolders() {
+    setState(() => _personalFoldersExpanded = !_personalFoldersExpanded);
+  }
+}

--- a/test/sidebar/linagora_sidebar_tree_list_test_utils.dart
+++ b/test/sidebar/linagora_sidebar_tree_list_test_utils.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+Future<void> pumpSidebarTreeList(WidgetTester tester, Widget child) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 204,
+          height: 180,
+          child: child,
+        ),
+      ),
+    ),
+  );
+}
+
+Rect sidebarTreeListRowRect(WidgetTester tester, String label) {
+  return tester.getRect(
+    find.ancestor(of: find.text(label), matching: find.byType(Material)).first,
+  );
+}
+
+Widget sidebarTreeListFolderItem(
+  BuildContext context,
+  LinagoraSidebarTreeListEntry<String> entry,
+) {
+  return LinagoraSidebarItem(label: entry.data, icon: Icons.folder_outlined);
+}

--- a/test/sidebar/linagora_sidebar_typography_test.dart
+++ b/test/sidebar/linagora_sidebar_typography_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+import 'linagora_sidebar_item_test_utils.dart';
+
+/// The row label, shared by mailbox and folder rows.
+const _labelSpec = (fontSize: 14.0, lineHeight: 18.4, letterSpacing: 0.25);
+
+/// The badge counter.
+const _badgeSpec = (fontSize: 11.0, lineHeight: 16.0, letterSpacing: 0.5);
+
+/// Every row icon is 16 square.
+const _iconSize = 16.0;
+
+/// The pill hugs its counter: 4.5px each side, 16px tall, never under 16 wide.
+const _badgePadding = 4.5;
+
+/// Primary text, carried at 90%, and the active blue, opaque.
+const _textPrimary = Color(0xFF424244);
+const _primaryMain = Color(0xFF0A84FF);
+
+typedef _TypeSpec = ({
+  double fontSize,
+  double lineHeight,
+  double letterSpacing,
+});
+
+void main() {
+  testWidgets('labels a row with body2', _labelFollowsTheSpec);
+  testWidgets('labels a badge with M3/label/small', _badgeFollowsTheSpec);
+  testWidgets('keeps the trailing text on the badge face', _trailingText);
+  testWidgets('keeps the label colour tied to the row state', _labelColour);
+  testWidgets('sizes the leading icon 16 square', _iconIsSixteen);
+  testWidgets('centres the badge counter in its pill', _badgeIsCentred);
+  testWidgets('hugs the badge counter, down to a round minimum', _badgeHugs);
+  testWidgets('centres the label against the row icon', _labelIsCentred);
+}
+
+Future<void> _labelFollowsTheSpec(WidgetTester tester) async {
+  await pumpSidebarItem(tester, const LinagoraSidebarItem(label: 'Inbox'));
+
+  _expectSpec(tester.widget<Text>(find.text('Inbox')).style, _labelSpec);
+}
+
+Future<void> _badgeFollowsTheSpec(WidgetTester tester) async {
+  await pumpSidebarItem(
+    tester,
+    const LinagoraSidebarItem(label: 'Inbox', badgeLabel: '999+'),
+  );
+
+  _expectSpec(tester.widget<Text>(find.text('999+')).style, _badgeSpec);
+}
+
+Future<void> _trailingText(WidgetTester tester) async {
+  late DefaultTextStyle inherited;
+  await pumpSidebarItem(
+    tester,
+    LinagoraSidebarItem(
+      label: 'Spam',
+      trailing: Builder(
+        builder: (context) {
+          inherited = DefaultTextStyle.of(context);
+          return const Text('Clean');
+        },
+      ),
+    ),
+  );
+
+  _expectSpec(inherited.style, _badgeSpec);
+  expect(
+    inherited.style.color,
+    LinagoraSidebarStyle.light().trailingForeground,
+  );
+  expect(inherited.textHeightBehavior, LinagoraSidebarStyle.middleAligned);
+}
+
+Future<void> _labelColour(WidgetTester tester) async {
+  final style = LinagoraSidebarStyle.light();
+
+  expect(style.foreground, _textPrimary.withValues(alpha: 0.9));
+  // The count is inked from the same token as the label it follows.
+  expect(style.badgeForeground, style.foreground);
+  expect(style.activeForeground, _primaryMain);
+
+  await pumpSidebarItem(
+    tester,
+    const LinagoraSidebarItem(label: 'Inbox', active: true),
+  );
+
+  expect(tester.widget<Text>(find.text('Inbox')).style?.color, _primaryMain);
+  // The type token carries no colour, so the row is free to set one.
+  expect(style.labelTextStyle.color, isNull);
+}
+
+Future<void> _iconIsSixteen(WidgetTester tester) async {
+  await pumpSidebarItem(
+    tester,
+    const LinagoraSidebarItem(label: 'Inbox', icon: Icons.inbox_outlined),
+  );
+
+  expect(LinagoraSidebarStyle.light().itemIconSize, _iconSize);
+  expect(
+    tester.getSize(find.byIcon(Icons.inbox_outlined)),
+    const Size.square(_iconSize),
+  );
+}
+
+/// The counter is laid out on its glyphs, not on the taller box its line
+/// height would leave around them, and centred across the pill.
+///
+/// Down the pill it is placed by its ink instead — see
+/// `linagora_sidebar_ink_test.dart`, which measures the painted pixels.
+Future<void> _badgeIsCentred(WidgetTester tester) async {
+  await _pumpBadge(tester, '999+');
+
+  final counter = tester.getRect(find.text('999+'));
+  final pill = tester.getRect(find.byType(LinagoraSidebarBadge));
+
+  expect(counter.center.dx, closeTo(pill.center.dx, 0.01));
+  expect(pill.contains(counter.topLeft), isTrue);
+  expect(pill.contains(counter.bottomRight), isTrue);
+  _expectGlyphBox(counter, '999+', _badgeSpec);
+}
+
+Future<void> _badgeHugs(WidgetTester tester) async {
+  final style = LinagoraSidebarStyle.light();
+  await _pumpBadge(tester, '999+');
+
+  final counter = tester.getRect(find.text('999+'));
+  final pill = tester.getRect(find.byType(LinagoraSidebarBadge));
+
+  expect(style.badgeHorizontalPadding, _badgePadding);
+  expect(pill.height, style.badgeHeight);
+  expect(pill.width, closeTo(counter.width + _badgePadding * 2, 0.01));
+}
+
+Future<void> _labelIsCentred(WidgetTester tester) async {
+  await pumpSidebarItem(
+    tester,
+    const LinagoraSidebarItem(label: 'Inbox', icon: Icons.inbox_outlined),
+  );
+
+  final label = tester.getRect(find.text('Inbox'));
+  final icon = tester.getRect(find.byIcon(Icons.inbox_outlined));
+
+  expect(label.center.dy, closeTo(icon.center.dy, 0.01));
+  _expectGlyphBox(label, 'Inbox', _labelSpec);
+}
+
+/// Standalone, so the pill is proven to lay out its own counter rather than
+/// inheriting what a row hands to its trailing slot.
+Future<void> _pumpBadge(WidgetTester tester, String label) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(child: LinagoraSidebarBadge(label: label)),
+      ),
+    ),
+  );
+}
+
+void _expectSpec(TextStyle? style, _TypeSpec spec) {
+  expect(style?.fontSize, spec.fontSize);
+  expect(style?.height, spec.lineHeight / spec.fontSize);
+  expect(style?.letterSpacing, spec.letterSpacing);
+  expect(style?.fontWeight, FontWeight.w500);
+}
+
+/// Asserts the text was laid out on its glyphs rather than on its line box,
+/// which is taller than them and hangs lower.
+void _expectGlyphBox(Rect box, String text, _TypeSpec spec) {
+  final glyphs = _glyphHeight(text, spec.fontSize);
+
+  expect(glyphs, lessThan(spec.lineHeight));
+  expect(box.height, closeTo(glyphs, 0.01));
+}
+
+double _glyphHeight(String text, double fontSize) {
+  final painter = TextPainter(
+    text: TextSpan(
+      text: text,
+      style: TextStyle(fontSize: fontSize),
+    ),
+    textDirection: TextDirection.ltr,
+    maxLines: 1,
+  );
+  try {
+    painter.layout();
+    final line = painter.computeLineMetrics().single;
+    return line.ascent + line.descent;
+  } finally {
+    painter.dispose();
+  }
+}

--- a/test/sidebar/linagora_sidebar_typography_test.dart
+++ b/test/sidebar/linagora_sidebar_typography_test.dart
@@ -135,17 +135,28 @@ Future<void> _badgeHugs(WidgetTester tester) async {
   expect(pill.width, closeTo(counter.width + _badgePadding * 2, 0.01));
 }
 
+/// The label shares a line with what sits either side of it.
+///
+/// Its box is the glyphs themselves, so centring the box centres the text a
+/// reader sees. On a line height's box the text would hang low inside it and
+/// the row would read as misaligned even with the boxes lined up.
 Future<void> _labelIsCentred(WidgetTester tester) async {
   await pumpSidebarItem(
     tester,
-    const LinagoraSidebarItem(label: 'Inbox', icon: Icons.inbox_outlined),
+    const LinagoraSidebarItem(
+      label: 'Personal folders',
+      icon: Icons.folder_outlined,
+      expanded: true,
+    ),
   );
 
-  final label = tester.getRect(find.text('Inbox'));
-  final icon = tester.getRect(find.byIcon(Icons.inbox_outlined));
+  final label = tester.getRect(find.text('Personal folders'));
+  final icon = tester.getRect(find.byIcon(Icons.folder_outlined));
+  final chevron = tester.getRect(find.byIcon(Icons.keyboard_arrow_down));
 
   expect(label.center.dy, closeTo(icon.center.dy, 0.01));
-  _expectGlyphBox(label, 'Inbox', _labelSpec);
+  expect(label.center.dy, closeTo(chevron.center.dy, 0.01));
+  _expectGlyphBox(label, 'Personal folders', _labelSpec);
 }
 
 /// Standalone, so the pill is proven to lay out its own counter rather than

--- a/widgetbook/lib/components/sidebar/linagora_sidebar_item_preview_configuration.dart
+++ b/widgetbook/lib/components/sidebar/linagora_sidebar_item_preview_configuration.dart
@@ -1,16 +1,5 @@
 part of 'linagora_sidebar_item_use_case.dart';
 
-const double _minSidebarWidth = 204;
-const double _defaultSidebarWidth = 204;
-
-/// The row can occupy the viewport minus the preview's own inset. Guarded so
-/// the slider always has a range, even on a viewport narrower than the floor.
-double _maxSidebarWidth(BuildContext context) {
-  final available =
-      MediaQuery.sizeOf(context).width - _SidebarPreviewSurface.padding * 2;
-  return available > _minSidebarWidth ? available : _minSidebarWidth + 1;
-}
-
 /// Knobs are registered while the use case builds, so a knob that only applies
 /// under another one is registered only when that one is on. It then leaves
 /// the panel entirely rather than sitting there doing nothing.
@@ -45,13 +34,7 @@ class _SidebarItemState {
       active: context.knobs.boolean(label: 'active', initialValue: false),
       hover: context.knobs.boolean(label: 'hover', initialValue: false),
       enabled: context.knobs.boolean(label: 'enabled', initialValue: true),
-      width: context.knobs.double.slider(
-        label: 'sidebar width',
-        initialValue: _defaultSidebarWidth,
-        min: _minSidebarWidth,
-        // Tracks the selected viewport, so the row cannot overflow it.
-        max: _maxSidebarWidth(context),
-      ),
+      width: SidebarPreviewSurface.widthKnob(context),
     );
   }
 }

--- a/widgetbook/lib/components/sidebar/linagora_sidebar_item_use_case.dart
+++ b/widgetbook/lib/components/sidebar/linagora_sidebar_item_use_case.dart
@@ -3,6 +3,8 @@ import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
+import 'sidebar_preview_surface.dart';
+
 part 'linagora_sidebar_item_preview_configuration.dart';
 part 'linagora_sidebar_item_preview_hover_trailing.dart';
 
@@ -25,7 +27,7 @@ Widget _primaryPreview(
   _SidebarItemContent content,
   _SidebarItemAffordances affordances,
 ) {
-  return _SidebarPreviewSurface(
+  return SidebarPreviewSurface(
     width: state.width,
     child: LinagoraSidebarItem(
       label: content.label,
@@ -41,39 +43,4 @@ Widget _primaryPreview(
       onTap: () {},
     ),
   );
-}
-
-/// Stands in for the sidebar shell, so the translucent fills composite over a
-/// realistic surface.
-class _SidebarPreviewSurface extends StatelessWidget {
-  const _SidebarPreviewSurface({required this.width, required this.child});
-
-  /// Inset around the row, subtracted from the viewport to get the width the
-  /// row can actually occupy.
-  static const double padding = 16;
-
-  /// Caps the row; the row itself fills whatever width it is given.
-  final double width;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-
-    return ColoredBox(
-      color: isDark ? const Color(0xFF272A31) : const Color(0xFFF3F6F9),
-      child: Padding(
-        padding: const EdgeInsets.all(padding),
-        child: Align(
-          alignment: Alignment.topLeft,
-          // A cap rather than a fixed width, so a value wider than the
-          // viewport simply fills it instead of overflowing.
-          child: ConstrainedBox(
-            constraints: BoxConstraints(maxWidth: width),
-            child: child,
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/widgetbook/lib/components/sidebar/linagora_sidebar_tree_list_use_case.dart
+++ b/widgetbook/lib/components/sidebar/linagora_sidebar_tree_list_use_case.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+import 'sidebar_preview_surface.dart';
+
+@widgetbook.UseCase(name: 'Virtualized folder tree', type: LinagoraSidebarTreeList)
+Widget linagoraSidebarTreeListUseCase(BuildContext context) {
+  return _SidebarTreeListPreview(
+    width: SidebarPreviewSurface.widthKnob(context),
+    rootFolderCount: context.knobs.int.slider(
+      label: 'Root folder count',
+      description: 'Number of folders at the first tree level.',
+      initialValue: 40,
+      min: 1,
+      max: 200,
+      divisions: 199,
+    ),
+    maximumDepth: context.knobs.int.slider(
+      label: 'Maximum depth',
+      description: 'Deepest nesting level shown in the preview tree.',
+      initialValue: 3,
+      min: 1,
+      max: 8,
+      divisions: 7,
+    ),
+    showNestedFolderIcons: context.knobs.boolean(
+      label: 'Show nested folder icons',
+      initialValue: true,
+    ),
+    showSelectedFolder: context.knobs.boolean(
+      label: 'Show selected folder',
+      initialValue: false,
+    ),
+  );
+}
+
+class _SidebarTreeListPreview extends StatefulWidget {
+  const _SidebarTreeListPreview({
+    required this.width,
+    required this.rootFolderCount,
+    required this.maximumDepth,
+    required this.showNestedFolderIcons,
+    required this.showSelectedFolder,
+  });
+
+  final double width;
+  final int rootFolderCount;
+  final int maximumDepth;
+  final bool showNestedFolderIcons;
+  final bool showSelectedFolder;
+
+  @override
+  State<_SidebarTreeListPreview> createState() =>
+      _SidebarTreeListPreviewState();
+}
+
+class _SidebarTreeListPreviewState extends State<_SidebarTreeListPreview> {
+  final Set<String> _expandedFolderIds = {
+    'personal',
+    'folder-0',
+    'folder-0-2',
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    // The surface already caps its child at the selected width; the list fills
+    // it, so a SizedBox here would only be a second copy of the same number.
+    return SidebarPreviewSurface(
+      width: widget.width,
+      child: LinagoraSidebarTreeList<_PreviewFolder>(
+        key: const PageStorageKey('sidebar-tree-list-preview'),
+        entries: _visibleEntries,
+        itemBuilder: _buildItem,
+      ),
+    );
+  }
+
+  List<LinagoraSidebarTreeListEntry<_PreviewFolder>> get _visibleEntries {
+    final entries = <LinagoraSidebarTreeListEntry<_PreviewFolder>>[
+      const LinagoraSidebarTreeListEntry(
+        id: 'personal',
+        data: _PreviewFolder(
+          id: 'personal',
+          label: 'Personal folders',
+          hasChildren: true,
+        ),
+      ),
+    ];
+    if (!_isExpanded('personal')) return entries;
+
+    for (var index = 0; index < widget.rootFolderCount; index++) {
+      _addFolder(entries, index: index, depth: 1);
+    }
+    return entries;
+  }
+
+  void _addFolder(
+    List<LinagoraSidebarTreeListEntry<_PreviewFolder>> entries, {
+    required int index,
+    required int depth,
+  }) {
+    final id = 'folder-$index${depth == 1 ? '' : '-$depth'}';
+    final hasChildren = index == 0 && depth < widget.maximumDepth;
+    entries.add(
+      LinagoraSidebarTreeListEntry(
+        id: id,
+        depth: depth,
+        data: _PreviewFolder(
+          id: id,
+          label: _folderLabel(index, depth),
+          hasChildren: hasChildren,
+        ),
+      ),
+    );
+    if (hasChildren && _isExpanded(id)) {
+      _addFolder(entries, index: index, depth: depth + 1);
+    }
+  }
+
+  String _folderLabel(int index, int depth) {
+    if (index != 0) return 'Folder ${index + 1}';
+    return switch (depth) {
+      1 => 'Project',
+      2 => 'Design',
+      _ => 'Subfolder $depth',
+    };
+  }
+
+  Widget _buildItem(
+    BuildContext context,
+    LinagoraSidebarTreeListEntry<_PreviewFolder> entry,
+  ) {
+    final folder = entry.data;
+    final expanded = _isExpanded(folder.id);
+    return LinagoraSidebarItem(
+      label: folder.label,
+      icon: entry.depth == 0 || widget.showNestedFolderIcons
+          ? Icons.folder_outlined
+          : null,
+      active: widget.showSelectedFolder && folder.id == 'folder-0',
+      expanded: folder.hasChildren ? expanded : null,
+      onExpandToggle: folder.hasChildren ? () => _toggle(folder.id) : null,
+      expandToggleLabel: folder.hasChildren
+          ? (expanded ? 'Collapse ${folder.label}' : 'Expand ${folder.label}')
+          : null,
+    );
+  }
+
+  bool _isExpanded(String id) => _expandedFolderIds.contains(id);
+
+  void _toggle(String id) {
+    setState(() {
+      if (!_expandedFolderIds.add(id)) _expandedFolderIds.remove(id);
+    });
+  }
+}
+
+class _PreviewFolder {
+  const _PreviewFolder({
+    required this.id,
+    required this.label,
+    required this.hasChildren,
+  });
+
+  final String id;
+  final String label;
+  final bool hasChildren;
+}

--- a/widgetbook/lib/components/sidebar/sidebar_preview_surface.dart
+++ b/widgetbook/lib/components/sidebar/sidebar_preview_surface.dart
@@ -1,0 +1,68 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+
+/// The sidebar-shell stand-in used to review translucent sidebar states.
+class SidebarPreviewSurface extends StatelessWidget {
+  const SidebarPreviewSurface({
+    super.key,
+    required this.width,
+    required this.child,
+  });
+
+  static const double padding = 16;
+  static const double defaultWidth = 204;
+
+  /// The width this surface can actually hand a preview: the selected viewport
+  /// minus its horizontal inset.
+  ///
+  /// The surface clamps its child to this, so a width above it is silently
+  /// discarded. Every width control derives its range from here to report the
+  /// width the preview really renders.
+  static double contentWidth(BuildContext context) {
+    final available = MediaQuery.sizeOf(context).width - padding * 2;
+    return math.max(0, available);
+  }
+
+  /// Registers the shared sidebar width knob and returns the chosen width.
+  ///
+  /// On a viewport too narrow for the minimum preview width there is a single
+  /// width that fits, so no knob is registered at all: widgetbook builds its
+  /// panel from the knobs a use case asks for, and a slider that cannot change
+  /// anything is better absent than dead.
+  static double widthKnob(BuildContext context) {
+    final content = contentWidth(context);
+    if (content <= defaultWidth) return content;
+
+    return context.knobs.double.slider(
+      label: 'Sidebar width',
+      description: 'Choose a preview width up to the selected viewport.',
+      initialValue: defaultWidth,
+      min: defaultWidth,
+      max: content,
+    );
+  }
+
+  final double width;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return ColoredBox(
+      color: isDark ? const Color(0xFF272A31) : const Color(0xFFF3F6F9),
+      child: Padding(
+        padding: const EdgeInsets.all(padding),
+        child: Align(
+          alignment: Alignment.topLeft,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: width),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/widgetbook/lib/widgetbook.dart
+++ b/widgetbook/lib/widgetbook.dart
@@ -9,6 +9,7 @@ import 'package:widgetbook_workspace/components/contact_component/phonebook_cont
 import 'package:widgetbook_workspace/components/list_item/linagora_setting_item_use_case.dart';
 import 'package:widgetbook_workspace/components/list_item/session_device_list_item_use_case.dart';
 import 'package:widgetbook_workspace/components/sidebar/linagora_sidebar_item_use_case.dart';
+import 'package:widgetbook_workspace/components/sidebar/linagora_sidebar_tree_list_use_case.dart';
 import 'package:widgetbook_workspace/components/text_field/linagora_text_field_use_case.dart';
 import 'package:widgetbook_workspace/components/typography/linagora_text_theme_use_case.dart';
 import 'package:widgetbook_workspace/custom/github_addon.dart';
@@ -182,6 +183,16 @@ class WidgetbookApp extends StatelessWidget {
         WidgetbookFolder(
           name: 'Sidebar',
           children: [
+            WidgetbookComponent(
+              name: 'Linagora sidebar tree list',
+              useCases: [
+                WidgetbookUseCase(
+                  name: 'Virtualized folder tree',
+                  builder: (context) =>
+                      linagoraSidebarTreeListUseCase(context),
+                ),
+              ],
+            ),
             WidgetbookComponent(
               name: 'Linagora sidebar item',
               useCases: [


### PR DESCRIPTION
## Issue

Related to [#4678](https://github.com/linagora/tmail-flutter/issues/4678).

**Branch:** `feature/tf-4678-sidebar-tree-list` → base `master`

The sidebar item state model (application-owned `active`, `expanded` and `enabled`) plus the virtualized folder tree.

- `LinagoraSidebarItem` state model and content layout
- `LinagoraSidebarSubItem`, `LinagoraSidebarIndent`
- `LinagoraSidebarTreeList` — virtualized, keyed rows that survive reordering


## Demo

https://github.com/user-attachments/assets/054ad50e-e615-4c18-ac2a-23241a5cb31d


